### PR TITLE
Imp 12 map cells

### DIFF
--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -276,6 +276,7 @@ namespace battleship{
 
 			Map *map = Map::getSingleton();
 
+			/*
 			for(Unit *u : mainPlayer->getSelectedUnits())
 				if(u->getType() == UnitType::UNDERWATER){
 					for(int i = 1; i < map->getNumTerrainObjects(); i++){
@@ -289,6 +290,7 @@ namespace battleship{
 						}
 					}
 				}
+			*/
 
 			targets.push_back(Order::Target((it != unitData.end() ? unitData[node] : unit), results[0].pos));
 		}

--- a/concreteGuiManager.cpp
+++ b/concreteGuiManager.cpp
@@ -217,6 +217,9 @@ namespace battleship{
 				listbox = new Listbox(pos, size, lines, maxDisplay, fontPath, closable);
 				break;
 			case UNITS:{
+				string path = GameManager::getSingleton()->getPath();
+				SOL_LUA_STATE.script("PATH = \"" + path + "\";");
+				SOL_LUA_STATE.script_file(path + "Scripts/unitData.lua");
 				bool vehicles = guiTable["vehicles"];
 				int numUnits = SOL_LUA_STATE["numUnits"];
 

--- a/concreteGuiManager.cpp
+++ b/concreteGuiManager.cpp
@@ -218,8 +218,6 @@ namespace battleship{
 				break;
 			case UNITS:{
 				string path = GameManager::getSingleton()->getPath();
-				SOL_LUA_STATE.script("PATH = \"" + path + "\";");
-				SOL_LUA_STATE.script_file(path + "Scripts/unitData.lua");
 				bool vehicles = guiTable["vehicles"];
 				int numUnits = SOL_LUA_STATE["numUnits"];
 

--- a/landTextureListbox.cpp
+++ b/landTextureListbox.cpp
@@ -22,7 +22,7 @@ namespace battleship{
 		MapEditorAppState::MapEditor *mapEditor = ((MapEditorAppState*)sm->getAppStateByType((int)AppStateType::MAP_EDITOR))->getMapEditor();
 	
 		Map *map = Map::getSingleton();
-		Material *mat = map->getTerrainObject(0).node->getMesh(0)->getMaterial();
+		Material *mat = map->getNodeParent()->getChild(0)->getMesh(0)->getMaterial();
 		Material::BoolUniform *texturingUniform = (Material::BoolUniform*)mat->getUniform("texturingEnabled");
 		Texture *landTex = mapEditor->getLandmassTexture(selectedOption);
 		string texUni = "textures[0]";

--- a/map.cpp
+++ b/map.cpp
@@ -240,9 +240,9 @@ namespace battleship{
 	}
 
 	void Map::preprareScene(){
-		nodeParent = new Node();
+		terrainNode = new Node();
 		Root *root = Root::getSingleton();
-		root->getRootNode()->attachChild(nodeParent);
+		root->getRootNode()->attachChild(terrainNode);
 
 		Camera *cam = root->getCamera();
 		cam->setPosition(Vector3(1, 1, 1) * 40);
@@ -251,7 +251,6 @@ namespace battleship{
 
     void Map::load(string mapName, bool empty) {
 		this->mapName = mapName;
-		cellSize = Vector3(7, 6, 7);
 		Pathfinder::getSingleton()->setImpassibleNodeVal(u16(0 - 1));
 		
 		preprareScene();
@@ -274,6 +273,7 @@ namespace battleship{
     void Map::unload() {}
 
 	int Map::getCellId(Vector3 pos, int id){
+		/*
 		Vector3 regionSize = terrainObjects[id].size;
 		Vector3 regionPos = terrainObjects[id].pos;
 		Vector3 cellSize = terrainObjects[id].cellSize;
@@ -287,24 +287,7 @@ namespace battleship{
 		int z = fabs(pos.z - initPos.z) / cellSize.z;
 
 		return (numCellsX * numCellsZ * y + (numCellsX * z + x));
-	}
-
-	bool Map::isPointWithinTerrainObject(Vector3 p, int id){
-		bool within;
-		Vector3 pos = terrainObjects[id].pos, size = terrainObjects[id].size;
-
-		if(terrainObjects[id].type == TerrainObject::RECT_WATERBODY)
-			within = (fabs(pos.x - p.x) < 0.5 * size.x && fabs(pos.z - p.z) < 0.5 * size.z);
-		else if(terrainObjects[id].type == TerrainObject::ROUND_WATERBODY)
-			within = Vector2(pos.x, pos.z).getDistanceFrom(Vector2(p.x, p.z)) < size.x;
-		else
-			within = true;
-
-		return within;
-	}
-
-	void Map::addTerrainObject(TerrainObject obj){
-		nodeParent->attachChild(obj.node);
-		terrainObjects.push_back(obj);
+		*/
+		return 0;
 	}
 }

--- a/map.cpp
+++ b/map.cpp
@@ -59,6 +59,7 @@ namespace battleship{
 		string texPath = "";
 		Quad *quad = nullptr;
 		Node *node = nullptr;
+		sol::state_view SOL_LUA_STATE = generateView();
 
 		if(id == -1){
 			string basePath = GameManager::getSingleton()->getPath() + "Models/Maps/" + mapName + "/";
@@ -167,6 +168,7 @@ namespace battleship{
 	}
 
 	void Map::loadCells(){
+		sol::state_view SOL_LUA_STATE = generateView();
 		int numCells = SOL_LUA_STATE[mapTable]["numCells"];
 		sol::table cellsTable = SOL_LUA_STATE[mapTable]["cells"];
 
@@ -200,13 +202,12 @@ namespace battleship{
 
 		Pathfinder::getSingleton()->setImpassibleNodeVal(u16(0 - 1));
 		string path = GameManager::getSingleton()->getPath();
-		SOL_LUA_STATE.script("PATH = \"" + path + "\"");
-		SOL_LUA_STATE.script_file(path + configData::scripts[1]);
+		sol::state_view SOL_LUA_STATE = generateView();
 		
 		preprareScene();
 
 		if(!empty){
-		sol::state_view SOL_LUA_STATE = generateView();
+			sol::state_view SOL_LUA_STATE = generateView();
 			SOL_LUA_STATE.script_file(GameManager::getSingleton()->getPath() + "Models/Maps/" + mapName + "/" + mapName + ".lua");
 			int numWaterbodies = SOL_LUA_STATE[mapTable]["numWaterBodies"];
 			

--- a/map.cpp
+++ b/map.cpp
@@ -201,7 +201,7 @@ namespace battleship{
 		int numSpawnPoints = SOL_LUA_STATE[mapTable]["numSpawnPoints"];
 
 		for(int i = 0; i < numSpawnPoints; i++){
-			sol::table posTable = SOL_LUA_STATE[mapTable]["spawnPointInd"][i + 1];
+			sol::table posTable = SOL_LUA_STATE[mapTable]["spawnPoints"][i + 1];
 			spawnPoints.push_back(Vector3(posTable["x"], posTable["y"], posTable["z"]));
 		}
 	}
@@ -218,7 +218,7 @@ namespace battleship{
 		string playerInd = "players";
 
 		for(int i = 0; i < numPlayers; i++){
-			int spawnPointId = SOL_LUA_STATE[mapTable]["spawnPointInd"][i + 1][spawnPointId];
+			//int spawnPointId = SOL_LUA_STATE[mapTable]["spawnPointInd"][i + 1][spawnPointId];
 			int numUnits = SOL_LUA_STATE[mapTable][playerInd][i + 1]["numUnits"];
 			
 			players.push_back(new Player(0, 0, 0, spawnPoints[i]));
@@ -251,7 +251,11 @@ namespace battleship{
 
     void Map::load(string mapName, bool empty) {
 		this->mapName = mapName;
+
 		Pathfinder::getSingleton()->setImpassibleNodeVal(u16(0 - 1));
+		string path = GameManager::getSingleton()->getPath();
+		SOL_LUA_STATE.script("PATH = \"" + path + "\"");
+		SOL_LUA_STATE.script_file(path + configData::scripts[1]);
 		
 		preprareScene();
 

--- a/map.cpp
+++ b/map.cpp
@@ -56,11 +56,12 @@ namespace battleship{
 	}
 
 	void Map::loadTerrainObject(int id){
-		string texPath = "", basePath = GameManager::getSingleton()->getPath() + "Models/Maps/" + mapName + "/";
+		string texPath = "";
 		Quad *quad = nullptr;
 		Node *node = nullptr;
 
 		if(id == -1){
+			string basePath = GameManager::getSingleton()->getPath() + "Models/Maps/" + mapName + "/";
 			texPath = basePath + (string)SOL_LUA_STATE[mapTable]["terrain"]["albedo"];
 
 			string terrainFile = basePath + (string)SOL_LUA_STATE[mapTable]["terrain"]["model"];
@@ -73,9 +74,9 @@ namespace battleship{
 		}
 		else{
 			sol::table waterBodyTable = SOL_LUA_STATE[mapTable]["waterbodies"][id + 1], posTable = waterBodyTable["pos"];
-			texPath = basePath + (string)waterBodyTable["albedo"];
+			texPath = GameManager::getSingleton()->getPath() + "Textures/Water/" + (string)waterBodyTable["albedo"];
 
-			quad = new Quad(Vector3(waterBodyTable["size"]["x"], waterBodyTable["size"]["z"], 1), true);
+			quad = new Quad(Vector3(waterBodyTable["size"]["x"], waterBodyTable["size"]["y"], 1), true);
 			Vector3 pos = Vector3(posTable["x"], posTable["y"], posTable["z"]);
 			node = new Node(pos);
 			node->attachMesh(quad);

--- a/map.h
+++ b/map.h
@@ -15,26 +15,27 @@ namespace vb01{
 
 namespace battleship{
 	class Player;
-	struct Cell;
-
-	struct Edge{
-		Cell *cellA, *cellB;
-		int weight;
-	};
-
-	struct Cell{
-		enum Type{LAND, WATER};
-
-		Type type;
-		vb01::Vector3 pos;
-		std::vector<Edge> edges;
-
-		Cell(){}
-		Cell(vb01::Vector3 p, Type t): pos(p), type(t){}
-	};
 
     class Map {
     public:
+		struct Cell;
+		
+		struct Edge{
+			Edge(vb01::s64 w, vb01::s64 src, vb01::s64 dest) : weight(w), srcCellId(src), destCellId(dest){}
+			vb01::s64 weight, srcCellId, destCellId;
+		};
+		
+		struct Cell{
+			enum Type{LAND, WATER};
+		
+			Type type;
+			vb01::Vector3 pos;
+			std::vector<Edge> edges;
+		
+			Cell(){}
+			Cell(vb01::Vector3 p, Type t, std::vector<Edge> e = std::vector<Edge>{}): pos(p), type(t), edges(e){}
+		};
+
 		static Map* getSingleton();
         ~Map(){}
         void update();

--- a/map.h
+++ b/map.h
@@ -10,6 +10,7 @@
 
 namespace vb01{
 	class Model;
+	class Material;
 	class Node;
 }
 
@@ -55,7 +56,8 @@ namespace battleship{
 		inline void addSpawnPoint(vb01::Vector3 sp){spawnPoints.push_back(sp);}
     private:
 		std::string mapTable = "map";
-		vb01::Node *terrainNode = nullptr;
+		vb01::Node *terrainNode = nullptr, *cellNode = nullptr;
+		vb01::Material *landCellMat = nullptr, *waterCellMat = nullptr;
 		std::string mapName;
 		vb01::Vector3 CELL_SIZE = vb01::Vector3(7, 7, 7);
 		std::vector<vb01::Vector3> spawnPoints;
@@ -67,6 +69,7 @@ namespace battleship{
 		void loadSpawnPoints();
 		void loadPlayers();
 		void loadSkybox();
+		void loadCells();
 		void loadTerrainObject(int);
     };
 }

--- a/map.h
+++ b/map.h
@@ -8,10 +8,6 @@
 #include <vector.h>
 #include <util.h>
 
-namespace gameBase{
-	class LuaManager;
-}
-
 namespace vb01{
 	class Model;
 	class Node;
@@ -19,35 +15,22 @@ namespace vb01{
 
 namespace battleship{
 	class Player;
+	struct Cell;
 
-	struct Cell{
-		bool land, impassible;
-		vb01::Vector3 pos;
-
-		Cell(){}
-		Cell(vb01::Vector3 p, bool l, bool i): pos(p), land(l), impassible(i){}
+	struct Edge{
+		Cell *cellA, *cellB;
+		int weight;
 	};
 
-	struct TerrainObject{
-		enum Type{LANDMASS, RECT_WATERBODY, ROUND_WATERBODY};
-		vb01::Vector3 pos, size, cellSize;
-		Type type;
-		vb01::Node *node = nullptr;
-		std::vector<vb01::Node*> cellMarkers;
-		int numCells;
-		Cell *cells = nullptr;
-		vb01::u32 **weights = nullptr;
+	struct Cell{
+		enum Type{LAND, WATER};
 
-		TerrainObject(){}
-		TerrainObject(vb01::Vector3 p, vb01::Vector3 s, vb01::Vector3 cs, Type t, vb01::Node *n, int num, Cell *c, vb01::u32 **w) :
-		   	pos(p),
-		   	size(s),
-		   	cellSize(cs),
-		   	type(t),
-		   	node(n),
-		   	numCells(num),
-		   	cells(c),
-		   	weights(w){}
+		Type type;
+		vb01::Vector3 pos;
+		std::vector<Edge> edges;
+
+		Cell(){}
+		Cell(vb01::Vector3 p, Type t): pos(p), type(t){}
 	};
 
     class Map {
@@ -59,13 +42,9 @@ namespace battleship{
         void unload();
 		int getCellId(vb01::Vector3, int);
 		bool isPointWithinTerrainObject(vb01::Vector3, int);
-		void addTerrainObject(TerrainObject);
 		inline std::string getMapName(){return mapName;}
-		inline TerrainObject& getTerrainObject(int i){return terrainObjects[i];}
-		inline int getNumTerrainObjects(){return terrainObjects.size();}
-		inline vb01::Node* getNodeParent(){return nodeParent;}
-		inline vb01::Vector3 getCellSize(){return cellSize;}
-		inline std::vector<TerrainObject>& getTerrainObjects(){return terrainObjects;} 
+		inline vb01::Node* getNodeParent(){return terrainNode;}
+		inline vb01::Vector3 getCellSize(){return CELL_SIZE;}
         inline std::vector<Player*> getPlayers() {return players;}
 		inline Player* getPlayer(int i){return players[i];}
 		inline void addPlayer(Player *p){players.push_back(p);}
@@ -75,12 +54,12 @@ namespace battleship{
 		inline void addSpawnPoint(vb01::Vector3 sp){spawnPoints.push_back(sp);}
     private:
 		std::string mapTable = "map";
-		vb01::Node *nodeParent = nullptr;
+		vb01::Node *terrainNode = nullptr;
 		std::string mapName;
-		std::vector<TerrainObject> terrainObjects;
-		vb01::Vector3 cellSize;
+		vb01::Vector3 CELL_SIZE = vb01::Vector3(7, 7, 7);
 		std::vector<vb01::Vector3> spawnPoints;
         std::vector<Player*> players;
+		std::vector<Cell> cells;
 
         Map(){}
 		void preprareScene();

--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -451,7 +451,7 @@ namespace battleship{
 		*/
 
 	vector<Map::Cell> MapEditorAppState::MapEditor::generateMapCells(){
-		Vector3 startPos = -.5 * Vector3(mapSize.x, 0, mapSize.y), cellSize = map->getCellSize();
+		Vector3 startPos = -.49 * Vector3(mapSize.x, 0, mapSize.y), cellSize = map->getCellSize();
 		int numHorCells = int(mapSize.x / cellSize.x);
 		int numVertCells = int(mapSize.y / cellSize.z);
 		vector<Map::Cell> cells;
@@ -459,10 +459,14 @@ namespace battleship{
 		for(int i = 0; i < numVertCells; i++)
 			for(int j = 0; j < numHorCells; j++){
 				vector<Ray::CollisionResult> res;
-				Ray::retrieveCollisions(startPos + Vector3(cellSize.x * i, 100, cellSize.z * j), -Vector3::VEC_J, map->getNodeParent()->getChild(0), res);
+				Vector3 rayPos = startPos + Vector3(cellSize.x * j, 100, cellSize.z * i);
+				Ray::retrieveCollisions(rayPos, -Vector3::VEC_J, map->getNodeParent()->getChild(0), res);
 				Ray::sortResults(res);
 
-				if(res.empty()) continue;
+				if(res.empty()){
+					cout << "Missed map from " << rayPos.x << " " << rayPos.y << " " << rayPos.z << "\n";
+			   		continue;
+				}
 				
 				//TODO implement logic to check if point is within water body
 
@@ -505,7 +509,7 @@ namespace battleship{
 		mapScript += "},\nplayers = {\n";
 
 		for(int i = 0; i < map->getNumPlayers(); i++){
-			mapScript += "spawnPoint = 0,\n";
+			mapScript += "{\nspawnPoint = 0,\n";
 
 			int numUnits = map->getPlayer(i)->getNumberOfUnits();
 			mapScript += "numUnits = " + to_string(numUnits) + ",\n";
@@ -528,10 +532,12 @@ namespace battleship{
 				}
 
 				mapScript += "}\n,";
-				mapScript += "}";
 			}
+
+			mapScript += "}\n";
 		}
-		mapScript += "\ncells = {\n";
+
+		mapScript += "},\ncells = {\n";
 		vector<Map::Cell> cells = generateMapCells();
 
 		for(Map::Cell cell : cells){
@@ -543,8 +549,6 @@ namespace battleship{
 
 			mapScript += "}\n},\n";
 		}
-
-		mapScript += "}\n";
 
 		mapScript += "},\n";
 

--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -272,8 +272,9 @@ namespace battleship{
 				Ray::sortResults(res);
 
 				if(res.empty()){
-					cout << "Missed map from " << rayPos.x << " " << rayPos.y << " " << rayPos.z << "\n";
-			   		continue;
+					Ray::CollisionResult r;
+					r.pos = Vector3(rayPos.x, 0, rayPos.z);
+					res.push_back(r);
 				}
 				
 				Map::Cell::Type type = Map::Cell::Type::LAND;

--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -492,7 +492,7 @@ namespace battleship{
 	}
 
 	void MapEditorAppState::MapEditor::generateMapScript(){
-		int numTerrObjs = map->getNodeParent()->getNumChildren();
+		int numTerrObjs = 0;
 		string mapScript = "map = {\nnumWaterBodies = " + to_string(numTerrObjs) + ",\n";
 		mapScript += "impassibleNodeValue = " + to_string(IMPASS_NODE_VAL) + ",\n";
 		mapScript += "numPlayers = " + to_string(map->getNumPlayers()) + ",\n";
@@ -537,12 +537,13 @@ namespace battleship{
 			mapScript += "}\n";
 		}
 
-		mapScript += "},\ncells = {\n";
 		vector<Map::Cell> cells = generateMapCells();
+		mapScript += "},\nnumCells = " + to_string(cells.size()) + ",\n";
+		mapScript += "cells = {\n";
 
 		for(Map::Cell cell : cells){
 			Vector3 p = cell.pos;
-			mapScript += "{type = '" + to_string((int)cell.type) + "', pos = {x = " + to_string(p.x) + ", y = " + to_string(p.y) + ", z = " + to_string(p.z) + "}, edges = {";
+			mapScript += "{type = " + to_string((int)cell.type) + ", pos = {x = " + to_string(p.x) + ", y = " + to_string(p.y) + ", z = " + to_string(p.z) + "}, numEdges = " + to_string(cell.edges.size()) + ", edges = {";
 
 			for(Map::Edge edge : cell.edges)
 				mapScript += "{srcCellId = " + to_string(edge.srcCellId) + ", destCellId = "  + to_string(edge.destCellId) + ", weight = "  + to_string(edge.weight) + "}, ";
@@ -566,7 +567,7 @@ namespace battleship{
 		}
 
 		mapScript += "skybox = \"" + skyboxPath + "\",\n";
-		//mapScript += "terrain = " + parseTerrainObject(map->getTerrainObject(0));
+		mapScript += "terrain = {model = \"" + map->getMapName()  + ".xml\", albedo = \"" + map->getMapName() + ".jpg\"},\n";
 		mapScript += "waterbodies = {";
 
 		for(int i = 1; i < numTerrObjs; i++){}

--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -67,12 +67,15 @@ namespace battleship{
 			circleRadius = MIN_RADIUS;
 	}
 
+	/*
 	void MapEditorAppState::MapEditor::toggleSelection(TerrainObject *obj, bool select){
 		obj->node->getMesh(0)->setWireframe(select);
 		selectedTerrainObject = (select ? obj : nullptr);
 	}
+	*/
 
 	void MapEditorAppState::MapEditor::castSelectionRay(){
+	/*
 		Camera *cam = Root::getSingleton()->getCamera();
 		Vector3 startPos = cam->getPosition();
 		Vector3 endPos = screenToSpace(getCursorPos());
@@ -92,9 +95,11 @@ namespace battleship{
 					break;
 				}
 		}
+	*/
 	}
 
 	void MapEditorAppState::MapEditor::createWaterbody(){
+		/*
 		Material *mat = new Material(Root::getSingleton()->getLibPath() + "texture");
 		mat->addBoolUniform("lightingEnabled", false);
 		mat->addBoolUniform("texturingEnabled", true);
@@ -118,10 +123,11 @@ namespace battleship{
 
 		prepareTerrainObjects(objId - 1, 1);
 		prepareCellMarkers(obj);
+		*/
 	}
 
 	void MapEditorAppState::MapEditor::moveTerrainObject(float strength){
-		Vector3 pos = selectedTerrainObject->node->getPosition();
+		Vector3 pos = selectedTerrainNode->getPosition();
 
 		switch(movementAxis){
 			case MovementAxis::X_AXIS:
@@ -135,12 +141,11 @@ namespace battleship{
 				break;
 		}
 
-		selectedTerrainObject->node->setPosition(pos);
-		selectedTerrainObject->pos = pos;
+		selectedTerrainNode->setPosition(pos);
 	}
 
 	void MapEditorAppState::MapEditor::pushLandmassVerts(float strength){
-		Mesh *mesh = map->getTerrainObject(0).node->getMesh(0);
+		Mesh *mesh = map->getNodeParent()->getChild(0)->getMesh(0);
 		MeshData meshData = mesh->getMeshBase();
 		MeshData::Vertex *verts = meshData.vertices;
 		int numVerts = meshData.numTris * 3;
@@ -169,13 +174,16 @@ namespace battleship{
 
 		Node *node = new Node();
 		node->attachMesh(mesh);
+		map->getNodeParent()->attachChild(node);
 
+		/*
 		TerrainObject::Type type = TerrainObject::LANDMASS;
 		Vector3 pos = Vector3::VEC_ZERO, s = Vector3(size.x, 0, size.y);
 		map->addTerrainObject(TerrainObject(pos, s, Vector3(14, 6, 14), type, node, 0, nullptr, nullptr));
 
 		prepareTerrainObjects(0, 1);
 		prepareCellMarkers(map->getTerrainObject(0));
+		*/
 	}
 
 	void MapEditorAppState::MapEditor::prepareTextures(string basePath, bool skybox, vector<Texture*> &textures){
@@ -227,7 +235,7 @@ namespace battleship{
 		XMLNode *nodeTag = rootTag->InsertEndChild(nodeEl);
 
 		XMLElement *meshEl = doc->NewElement("mesh");
-		MeshData meshData = map->getTerrainObject(0).node->getMesh(0)->getMeshBase();
+		MeshData meshData;
 		meshEl->SetAttribute("name", "mesh");
 		meshEl->SetAttribute("num_faces", meshData.numTris);
 		meshEl->SetAttribute("num_vertex_groups", 0);
@@ -275,6 +283,7 @@ namespace battleship{
 	}
 
 	void MapEditorAppState::MapEditor::prepareTerrainObject(u32 **weights, Cell *cells, int cellsByDim[3], float height, bool land){
+		/*
 		const int numCells = cellsByDim[0] * cellsByDim[1] * cellsByDim[2];
 		Vector3 initPos = -.5 * Vector3(mapSize.x, -height, mapSize.y);
 
@@ -371,9 +380,11 @@ namespace battleship{
 		            weights[i][j] = 1;
 			}
 		}
+		*/
 	}
 
 	void MapEditorAppState::MapEditor::prepareTerrainObjects(int startId, int numObjs){
+		/*
 		if(numObjs == -1)
 			numObjs = map->getNumTerrainObjects();
 
@@ -400,8 +411,10 @@ namespace battleship{
 
 			prepareTerrainObject(weights, cells, cellsByDim, (i > 0 ? obj.pos.y : 0), i == 0);
 		}
+		*/
 	}
 
+		/*
 	string MapEditorAppState::MapEditor::parseTerrainObject(TerrainObject &terrObj){
 		string terrObjStr = "{\n";
 
@@ -435,8 +448,10 @@ namespace battleship{
 
 		return terrObjStr;
 	}
+		*/
 
 	void MapEditorAppState::MapEditor::parseMapScript(){
+		/*
 		int numTerrObjs = map->getNumTerrainObjects();
 		string mapScript = "map = {\nnumWaterBodies = " + to_string(numTerrObjs) + ",\n";
 		mapScript += "impassibleNodeValue = " + to_string(IMPASS_NODE_VAL) + ",\n";
@@ -510,16 +525,20 @@ namespace battleship{
 		std::ofstream outFile(file);
 		outFile << mapScript;
 		outFile.close();
+		*/
 	}
 
 	void MapEditorAppState::MapEditor::toggleCellMarkers(){
+		/*
 		cellMarkersVisible = !cellMarkersVisible;
 
 		for(TerrainObject &obj : map->getTerrainObjects())
 			for(Node *cellMarker : obj.cellMarkers)
 				cellMarker->setVisible(cellMarkersVisible);
+		 */
 	}
 
+	/*
 	void MapEditorAppState::MapEditor::prepareCellMarkers(TerrainObject &obj){
 		Root *root = Root::getSingleton();
 		Node *rootNode = root->getRootNode();
@@ -540,6 +559,7 @@ namespace battleship{
 			obj.cellMarkers.push_back(cellMarker);
 		}
 	}
+	*/
 
 	void MapEditorAppState::MapEditor::exportMap(){
 		string assetsPath = GameManager::getSingleton()->getPath();
@@ -635,7 +655,7 @@ namespace battleship{
 					Vector3 endPos = screenToSpace(cursorPos);
 
 					vector<Ray::CollisionResult> results;
-					Ray::retrieveCollisions(startPos, (endPos - startPos).norm(), Map::getSingleton()->getTerrainObject(0).node, results);
+					Ray::retrieveCollisions(startPos, (endPos - startPos).norm(), Root::getSingleton()->getRootNode(), results);
 					Ray::sortResults(results);
 
 
@@ -658,12 +678,14 @@ namespace battleship{
 			case Bind::CREATE_WATERBODY:
 				if(isPressed) mapEditor->createWaterbody();
 				break;
+				/*
 			case Bind::MOVE_TERR_OBJ:
 				if(isPressed) mapEditor->setMovingTerrainObject(true);
 				break;
 			case Bind::STOP_TERR_OBJ:
 				if(isPressed) mapEditor->setMovingTerrainObject(false);
 				break;
+				 */
 			case Bind::MOVE_X_AXIS:
 			case Bind::MOVE_Y_AXIS:
 			case Bind::MOVE_Z_AXIS:
@@ -701,6 +723,7 @@ namespace battleship{
 					camCtr->orientCamera(Vector3(0, 1, 0), strength);
 
 				break;
+				/*
 			case Bind::PUSH_VERTS_UP:
 			case Bind::PUSH_VERTS_DOWN:
 				if(mapEditor->isPushing()) mapEditor->pushLandmassVerts(strength);
@@ -708,6 +731,7 @@ namespace battleship{
 					mapEditor->moveTerrainObject(strength);
 
 				break;
+				 */
 		}
 	}
 }

--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -286,7 +286,7 @@ namespace battleship{
 					Vector3 waterPos = terrainNode->getChild(k)->getPosition();
 					Vector3 waterSize = ((Quad*)terrainNode->getChild(k)->getMesh(0))->getSize();
 
-					if(fabs(res[0].pos.x - waterPos.x) < .5 * cellSize.x && fabs(res[0].pos.z - waterPos.z) < .5 * cellSize.z){
+					if(fabs(res[0].pos.x - waterPos.x) < .5 * waterSize.x && fabs(res[0].pos.z - waterPos.z) < .5 * waterSize.y){
 						type = Map::Cell::Type::WATER;
 						pos.y = waterPos.y;
 						waterBodyBedPoints.push_back(pair(numVertCells * i + j, res[0].pos.y));
@@ -296,18 +296,31 @@ namespace battleship{
 
 				vector<Map::Edge> edges;
 				int weight = 1;
+				bool up = (i > 0), right = (j < numHorCells - 1), down = (i < numVertCells - 1), left = (j > 0);
 
-				if(j > 0)
+				if(left)
 					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * i + j - 1));
 
-				if(j < numHorCells - 1)
+				if(right)
 					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * i + j + 1));
 
-				if(i > 0)
+				if(up)
 					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * (i - 1) + j));
 
-				if(i < numVertCells - 1)
+				if(down)
 					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * (i + 1) + j));
+
+				if(up && left)
+					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * (i - 1) + j - 1));
+
+				if(up && right)
+					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * (i - 1) + j + 1));
+
+				if(down && left)
+					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * (i + 1) + j - 1));
+
+				if(down && right)
+					edges.push_back(Map::Edge(weight, numVertCells * i + j, numVertCells * (i + 1) + j + 1));
 
 				cells.push_back(Map::Cell(pos, type, edges));
 			}

--- a/mapEditorAppState.h
+++ b/mapEditorAppState.h
@@ -37,7 +37,6 @@ namespace battleship{
 					void moveTerrainObject(float);
 					void exportMap();
 					void prepareTerrainObjects(int = 0, int = -1);
-					void toggleCellMarkers();
 					inline vb01::Node* getSelectedNode(){return selectedTerrainNode;}
 					inline float getGuiThreshold(){return guiThreshold;}
 					inline float getCircleRadius(){return circleRadius;}
@@ -54,14 +53,11 @@ namespace battleship{
 				private:
 					void generatePlane(vb01::Vector2);
 					void prepareTextures(std::string, bool, std::vector<vb01::Texture*>&);
-					//void toggleSelection(TerrainObject*, bool);
+					void toggleSelection(vb01::Node*, bool);
 					std::vector<Map::Cell> generateMapCells();
 					void generateLandmassXml();
-					//std::string parseTerrainObject(TerrainObject&);
 					void generateMapScript();
-					void deleteWeights();
 					void prepareTerrainObject(vb01::u32**, Map::Cell*, int[3], float, bool);
-					//void prepareCellMarkers(TerrainObject&);
 
 					Map *map;
 					vb01::Node *selectedTerrainNode = nullptr;

--- a/mapEditorAppState.h
+++ b/mapEditorAppState.h
@@ -18,7 +18,6 @@ namespace vb01{
 
 namespace battleship{
 	class MapEditor;
-	class TerrainObject;
 
 	class MapEditorAppState : public gameBase::AbstractAppState{
 		public:
@@ -39,7 +38,7 @@ namespace battleship{
 					void exportMap();
 					void prepareTerrainObjects(int = 0, int = -1);
 					void toggleCellMarkers();
-					inline TerrainObject* getSelectedTerrainObject(){return selectedTerrainObject;}
+					inline vb01::Node* getSelectedNode(){return selectedTerrainNode;}
 					inline float getGuiThreshold(){return guiThreshold;}
 					inline float getCircleRadius(){return circleRadius;}
 					inline bool isPushing(){return pushing;}
@@ -55,16 +54,16 @@ namespace battleship{
 				private:
 					void generatePlane(vb01::Vector2);
 					void prepareTextures(std::string, bool, std::vector<vb01::Texture*>&);
-					void toggleSelection(TerrainObject*, bool);
+					//void toggleSelection(TerrainObject*, bool);
 					void parseLandmass();
-					std::string parseTerrainObject(TerrainObject&);
+					//std::string parseTerrainObject(TerrainObject&);
 					void parseMapScript();
 					void deleteWeights();
 					void prepareTerrainObject(vb01::u32**, Cell*, int[3], float, bool);
-					void prepareCellMarkers(TerrainObject&);
+					//void prepareCellMarkers(TerrainObject&);
 
 					Map *map;
-					TerrainObject *selectedTerrainObject = nullptr;
+					vb01::Node *selectedTerrainNode = nullptr;
 					MovementAxis movementAxis = X_AXIS;
 					vb01Gui::Listbox *skyListbox = nullptr;
 					bool pushing = false, movingTerrainObject = false, weightsGenerated = false, newMap, cellMarkersVisible = false;

--- a/mapEditorAppState.h
+++ b/mapEditorAppState.h
@@ -55,11 +55,12 @@ namespace battleship{
 					void generatePlane(vb01::Vector2);
 					void prepareTextures(std::string, bool, std::vector<vb01::Texture*>&);
 					//void toggleSelection(TerrainObject*, bool);
-					void parseLandmass();
+					std::vector<Map::Cell> generateMapCells();
+					void generateLandmassXml();
 					//std::string parseTerrainObject(TerrainObject&);
-					void parseMapScript();
+					void generateMapScript();
 					void deleteWeights();
-					void prepareTerrainObject(vb01::u32**, Cell*, int[3], float, bool);
+					void prepareTerrainObject(vb01::u32**, Map::Cell*, int[3], float, bool);
 					//void prepareCellMarkers(TerrainObject&);
 
 					Map *map;

--- a/player.cpp
+++ b/player.cpp
@@ -13,16 +13,14 @@ namespace battleship{
         this->spawnPoint = spawnPoint;
 		this->id = id;
 
-		sol::state_view SOL_LUA_STATE = generateView();
-		SOL_LUA_STATE.script("players[" + to_string(id + 1) + "] = Player:new({id = " + to_string(id + 1) + "})");
+		//SOL_LUA_STATE.script("players[" + to_string(id + 1) + "] = Player:new({id = " + to_string(id + 1) + "})");
     }
 
     Player::~Player() {
     }
 
     void Player::update() {
-		sol::state_view SOL_LUA_STATE = generateView();
-		SOL_LUA_STATE.script("players[" + to_string(id + 1) + "]:update()");
+		//SOL_LUA_STATE.script("players[" + to_string(id + 1) + "]:update()");
 
 		for(Unit *u : units)
 			u->update();

--- a/unitFrameController.cpp
+++ b/unitFrameController.cpp
@@ -43,7 +43,7 @@ namespace battleship{
 	//TODO implement terrain evenness check
 	void UnitFrameController::update(){
 		Map *map = Map::getSingleton();
-		MeshData meshData = map->getTerrainObject(0).node->getMesh(0)->getMeshBase();
+		MeshData meshData;
 		MeshData::Vertex *verts = meshData.vertices;
 		int numVerts = 3 * meshData.numTris;
 
@@ -56,7 +56,7 @@ namespace battleship{
 
 		for(UnitFrame &s : unitFrames){
 			vector<Ray::CollisionResult> results;
-			Ray::retrieveCollisions(startPos, (endPos - startPos).norm(), map->getTerrainObject(0).node, results);
+			Ray::retrieveCollisions(startPos, (endPos - startPos).norm(), map->getNodeParent()->getChild(0), results);
 			Ray::sortResults(results);
 
 			if(!results.empty()){

--- a/unitFrameController.cpp
+++ b/unitFrameController.cpp
@@ -43,7 +43,7 @@ namespace battleship{
 	//TODO implement terrain evenness check
 	void UnitFrameController::update(){
 		Map *map = Map::getSingleton();
-		MeshData meshData;
+		MeshData meshData = map->getNodeParent()->getChild(0)->getMesh(0)->getMeshBase();
 		MeshData::Vertex *verts = meshData.vertices;
 		int numVerts = 3 * meshData.numTris;
 
@@ -64,8 +64,8 @@ namespace battleship{
 					s.model->setPosition(results[0].pos);
 
 				sol::table unitTable = SOL_LUA_STATE["unitCornerPoints"][s.id + 1]; 
-    			float width = (int)unitTable[1]["x"] - (int)unitTable[2]["x"];
-    			float length = (int)unitTable[4]["z"] - (int)unitTable[1]["z"];
+    			float width = (float)unitTable[1]["x"] - (float)unitTable[2]["x"];
+    			float length = (float)unitTable[4]["z"] - (float)unitTable[1]["z"];
 
 				float unevenness = 0;
 

--- a/vehicle.cpp
+++ b/vehicle.cpp
@@ -108,6 +108,7 @@ namespace battleship{
 	}
 
 	void Vehicle::alignToSurface(){
+		/*
 		Map *map = Map::getSingleton();
 		TerrainObject terr = map->getTerrainObject(0);
 		vector<Ray::CollisionResult> res;
@@ -122,6 +123,7 @@ namespace battleship{
 			Quaternion rotQuat = Quaternion(angle, axis);
 			orientUnit(rotQuat * rot);
 		}
+		*/
 	}
 
     void Vehicle::move(Order order) {
@@ -138,6 +140,7 @@ namespace battleship{
 		int srcObjId = 0, destObjId = 0;
 		Map *map = Map::getSingleton();
 
+		/*
 		for(int i = 1; i < map->getNumTerrainObjects(); i++){
 			if(map->isPointWithinTerrainObject(pos, i))
 				srcObjId = i;
@@ -145,6 +148,7 @@ namespace battleship{
 			if(map->isPointWithinTerrainObject(order.targets[0].pos, i))
 				destObjId = i;
 		}
+		 */
 
 		if(srcObjId != destObjId)
 			return;
@@ -152,6 +156,7 @@ namespace battleship{
 		int source = map->getCellId(pos, srcObjId);
 		int dest = map->getCellId(order.targets[0].pos, destObjId);
 
+		/*
 		Pathfinder *pathfinder = Pathfinder::getSingleton();
 		u32 **weights = map->getTerrainObject(srcObjId).weights;
 		vector<int> path = pathfinder->findPath(weights, map->getTerrainObject(srcObjId).numCells, source, dest);
@@ -166,5 +171,6 @@ namespace battleship{
 		if(!(impassibleNodePresent || path.empty()))
 			for(int p : path)
 				pathPoints.push_back(map->getTerrainObject(srcObjId).cells[p].pos);
+		*/
 	}
 }


### PR DESCRIPTION
Refactored map structure to generate and store cells directly instead of `TerrainObject`s.

Steps to test:
1) export a new map using the map editor
2) open the map in singleplayer mode
3) look for green (land) and blue (water) cells, denoted by wireframe quads.
![imp-12-cells](https://github.com/devZoGok/Battleship/assets/51003244/86c11e10-19fb-4aed-b7e5-0ae86e92bcb9)
