### PR TITLE
fixed landmass vert pushing/pulling

### DIFF
--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -138,6 +138,7 @@ namespace battleship{
 		MeshData meshData = mesh->getMeshBase();
 		MeshData::Vertex *verts = meshData.vertices;
 		int numVerts = meshData.numTris * 3;
+		pushPos.y += 10 * strength;
 
 		for(int i = 0; i < numVerts; i++){
 			Vector3 distVec = verts[i].pos - pushPos;
@@ -145,7 +146,7 @@ namespace battleship{
 			float dist = distVec.getLength();
 
 			if(dist < circleRadius)
-				verts[i].pos.y += 10 * strength * dist / circleRadius;
+				verts[i].pos.y = oldLandmassVertHeights[i] + pushPos.y - (pushPos.y / circleRadius) * dist;
 		}
 
 		mesh->updateVerts(meshData);
@@ -164,6 +165,8 @@ namespace battleship{
 		Node *node = new Node();
 		node->attachMesh(mesh);
 		map->getNodeParent()->attachChild(node);
+
+		oldLandmassVertHeights = new float[3 * mesh->getMeshBase().numTris];
 	}
 
 	void MapEditorAppState::MapEditor::prepareTextures(string basePath, bool skybox, vector<Texture*> &textures){
@@ -468,6 +471,18 @@ namespace battleship{
 		generateMapScript();
 	}
 
+	void MapEditorAppState::MapEditor::togglePush(bool push){
+		this->pushing = push;
+
+		if(push){
+			MeshData meshData = map->getNodeParent()->getChild(0)->getMesh(0)->getMeshBase();
+			int numVerts = 3 * meshData.numTris;
+
+			for(int i = 0; i < numVerts; i++)
+				oldLandmassVertHeights[i] = meshData.vertices[i].pos.y;
+		}
+	}
+
 	MapEditorAppState::MapEditorAppState(string name, Vector2 size, bool newMap) : AbstractAppState(
 					AppStateType::MAP_EDITOR,
 				 	configData::calcSumBinds(AppStateType::MAP_EDITOR, true),
@@ -554,10 +569,9 @@ namespace battleship{
 					Ray::retrieveCollisions(startPos, (endPos - startPos).norm(), Root::getSingleton()->getRootNode(), results);
 					Ray::sortResults(results);
 
-
 					if(cursorPos.y < GameManager::getSingleton()->getHeight() - mapEditor->getGuiThreshold()){
 						bool push = !results.empty();
-						mapEditor->setPushing(push);
+						mapEditor->togglePush(push);
 
 						if(push)
 							mapEditor->setPushPos(results[0].pos);
@@ -565,10 +579,10 @@ namespace battleship{
 						mapEditor->castSelectionRay();
 					}
 					else
-						mapEditor->setPushing(false);
+						mapEditor->togglePush(false);
 				}
 				else
-					mapEditor->setPushing(false);
+					mapEditor->togglePush(false);
 
 				break;
 			case Bind::CREATE_WATERBODY:

--- a/mapEditorAppState.h
+++ b/mapEditorAppState.h
@@ -37,11 +37,11 @@ namespace battleship{
 					void moveTerrainObject(float);
 					void exportMap();
 					void prepareTerrainObjects(int = 0, int = -1);
+					void togglePush(bool);
 					inline vb01::Node* getSelectedNode(){return selectedTerrainNode;}
 					inline float getGuiThreshold(){return guiThreshold;}
 					inline float getCircleRadius(){return circleRadius;}
 					inline bool isPushing(){return pushing;}
-					inline void setPushing(bool p){pushing = p;}
 					inline void setPushPos(vb01::Vector3 p){pushPos = p;}
 					inline bool isMovingTerrainObject(){return movingTerrainObject;}
 					inline void setMovingTerrainObject(bool m){movingTerrainObject = m;}
@@ -63,6 +63,7 @@ namespace battleship{
 					vb01::Node *selectedTerrainNode = nullptr;
 					MovementAxis movementAxis = X_AXIS;
 					vb01Gui::Listbox *skyListbox = nullptr;
+					float *oldLandmassVertHeights = nullptr;
 					bool pushing = false, movingTerrainObject = false, weightsGenerated = false, newMap, cellMarkersVisible = false;
 					const float MIN_RADIUS = 1, MAX_RADIUS = 100, INCREASE_RATE = 1;
 					const int NUM_SUBDIVS = 100;


### PR DESCRIPTION
Fixed abrupt change in elevation for border verts.

Steps to replicate:
1) create a new map in the map editor
2) increase the radius to a desired size
3) attempt to push or pull verts