### PR TITLE
Bf 123 windows argv

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -14,13 +14,17 @@ using namespace vb01;
 using namespace std;
 
 int main(int argc, char **argv) {
-    GameManager *gm = GameManager::getSingleton();
-
 	string gamePath = string(argv[0]);
+
+	for(int i = 0; i < gamePath.length(); i++)
+		if(gamePath[i] == '\\')
+			gamePath[i] = '/';
+
 	gamePath = gamePath.substr(0, gamePath.find_last_of("/") + 1) + "../";
+
+    GameManager *gm = GameManager::getSingleton();
 	gm->start(gamePath);
     gm->getStateManager()->attachAppState(new GuiAppState());
-
 	AssetManager::getSingleton()->load(gm->getPath() + "Fonts/batang.ttf");
 
 	ConcreteGuiManager::getSingleton()->readLuaScreenScript("mainMenu.lua");


### PR DESCRIPTION
Replacing backslashes with forward slashes for `argv` paths. To test, run the game on Windows.