### PR TITLE
only selecting units on screen

### DIFF
--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -253,7 +253,11 @@ namespace battleship{
 			   	obj->getUpVec() * (corners[i].y + hitboxOffset.y) + 
 				obj->getDirVec() * (corners[i].z + hitboxOffset.z);
 
-			cornersOnScreen[i] = spaceToScreen(cornerInWorld);
+			Vector3 screenSpace3d = spaceToScreen3d(cornerInWorld);
+
+			if(fabs(screenSpace3d.z) > 1) return false;
+
+			cornersOnScreen[i] = Vector2(screenSpace3d.x, screenSpace3d.y);
 		}
 
 		vector<Vector2> selectionPoints;


### PR DESCRIPTION
Fixed off-screen unit selection. To test:
1) turn the camera away from a unit
2) move the camera so that the unit would be selected before the bug fix
3) try selecting the unit behind the camera