### PR TITLE
Bf 172 wrong orders

### DIFF
--- a/factory.cpp
+++ b/factory.cpp
@@ -73,7 +73,7 @@ namespace battleship{
 			if(trainingStatus >= 100){
 				Unit *unit = GameObjectFactory::createUnit(player, unitQueue[0], pos, rot);
 				player->addUnit(unit);
-				unit->setOrder(Order(Order::TYPE::MOVE, vector<Order::Target>{Order::Target(nullptr, pos + 30 * dirVec)}, Vector3::VEC_ZERO));
+				unit->receiveOrder(Order(Order::TYPE::MOVE, vector<Order::Target>{Order::Target(nullptr, pos + 30 * dirVec)}, Vector3::VEC_ZERO), false);
 
 				unitQueue.erase(unitQueue.begin());
 				trainingStatus = 0;

--- a/player.cpp
+++ b/player.cpp
@@ -88,21 +88,7 @@ namespace battleship{
 	}
 
 	void Player::issueOrder(Order::TYPE type, Vector3 destDir, vector<Order::Target> targets, bool append){
-		if(type != Order::TYPE::EJECT && targets.empty()) return;
-
 		vector<Unit*> selectedUnits = getSelectedUnits();
-
-		if(type == Order::TYPE::EJECT){
-			for(Unit *u : selectedUnits){
-				const vector<Unit::GarrisonSlot> &garrisonSlots = u->getGarrisonSlots();
-
-				for(Unit::GarrisonSlot slot : garrisonSlots)
-					if(slot.vehicle)
-						targets.push_back(Order::Target((Unit*)slot.vehicle));
-			}
-		}
-		else if(type != Order::TYPE::PATROL)
-			targets.push_back(Order::Target());
 
         for (Unit *u : selectedUnits) {
 			bool targetingSelf = false, structBuilt = true;
@@ -124,15 +110,10 @@ namespace battleship{
 			int lineId = -1;
 			ActiveGameState *activeState = ((ActiveGameState*)GameManager::getSingleton()->getStateManager()->getAppStateByType(AppStateType::ACTIVE_STATE));
 
-			if(activeState && activeState->getPlayer() == this)
+			if(activeState && activeState->getPlayer() == this && type != Order::TYPE::EJECT)
 				lineId = getOrderLineId(type, u->getPos(), targets[0].pos);
 
-        	Order order(type, targets, destDir, lineId);
-
-            if (append)
-                u->addOrder(order);
-            else
-                u->setOrder(order);
+			u->receiveOrder(Order(type, targets, destDir, lineId), append);
         }
 	}
 

--- a/unit.cpp
+++ b/unit.cpp
@@ -544,7 +544,7 @@ namespace battleship{
 		if(orders.empty())
 			for(Unit *unit : units)
 				if(unit->getPos().getDistanceFrom(pos) < lineOfSight){
-					setOrder(Order(Order::TYPE::ATTACK, vector<Order::Target>{Order::Target(unit)}, Vector3::VEC_ZERO, -1, false));
+					receiveOrder(Order(Order::TYPE::ATTACK, vector<Order::Target>{Order::Target(unit)}, Vector3::VEC_ZERO, -1, false), false);
 					break;
 				}
 	}
@@ -651,17 +651,16 @@ namespace battleship{
 				adjWaterCellId = edge.destCellId;
 		}
 
-		if(garrisonSlots.size() > 0){
-			for(Order::Target targ : order.targets){
-				bool exitToLandCell = (targ.unit->getType() == UnitType::LAND && adjLandCellId != -1);
-				bool exitToWaterCell = ((targ.unit->getType() == UnitType::SEA_LEVEL || targ.unit->getType() == UnitType::UNDERWATER) && adjWaterCellId != -1);
-
+		for(GarrisonSlot &slot : garrisonSlots)
+			if(slot.vehicle){
+				bool exitToLandCell = (slot.vehicle->getType() == UnitType::LAND && adjLandCellId != -1);
+				bool exitToWaterCell = ((slot.vehicle->getType() == UnitType::SEA_LEVEL || slot.vehicle->getType() == UnitType::UNDERWATER) && adjWaterCellId != -1);
+				
 				if(exitToLandCell || exitToWaterCell)
-					((Vehicle*)targ.unit)->exitGarrisonable(cells[exitToLandCell ? adjLandCellId : adjWaterCellId].pos);
+					slot.vehicle->exitGarrisonable(cells[exitToLandCell ? adjLandCellId : adjWaterCellId].pos);
 			}
 
-			removeOrder(0);
-		}
+		removeOrder(0);
 	}
 
 	void Unit::attack(Order order){
@@ -681,12 +680,53 @@ namespace battleship{
 			}
 	}
 
-    void Unit::setOrder(Order order) {
-        while (!orders.empty())
-			removeOrder(0);
+	bool Unit::validateOrder(Order order){
+		switch (order.type) {
+		    case Order::TYPE::ATTACK:
+				return !weapons.empty();
+		    case Order::TYPE::BUILD:
+				return unitClass == UnitClass::ENGINEER;
+		    case Order::TYPE::PATROL:
+		    case Order::TYPE::MOVE:
+				return vehicle;
+			case Order::TYPE::GARRISON:
+				return true;
+			case Order::TYPE::EJECT:
+				return !garrisonSlots.empty();
+		    case Order::TYPE::LAUNCH:
+				{
+					for(Weapon *weapon : weapons)
+						if(weapon->getType() == Weapon::Type::CRUISE_MISSILE)
+							return true;
 
-        addOrder(order);
-        orderLineDispTime = getTime();
+					return false;
+				}
+		    case Order::TYPE::SUPPLY:
+				return unitClass == UnitClass::RESOURCE_ROVER;
+		    case Order::TYPE::HACK:
+				{
+					for(Weapon *weapon : weapons)
+						if(weapon->getType() == Weapon::Type::CRUISE_MISSILE)
+							return true;
+
+					return false;
+				}
+			default:
+				return false;
+		}
+	}
+
+    void Unit::receiveOrder(Order order, bool add) {
+		if(!validateOrder(order)) return;
+
+		if(!add){
+			while (!orders.empty())
+				removeOrder(0);
+			
+			orderLineDispTime = getTime();
+		}
+
+		orders.push_back(order);
     }
 
     void Unit::halt() {
@@ -705,10 +745,6 @@ namespace battleship{
 				break;
 			}
 		}
-	}
-
-	void Unit::addOrder(Order order){
-		orders.push_back(order);
 	}
 
 	vector<Player*> Unit::getSelectingPlayers(){

--- a/unit.h
+++ b/unit.h
@@ -133,7 +133,7 @@ namespace battleship{
         virtual void select();
         void setOrder(Order);
         std::vector<Projectile*> getProjectiles();
-        virtual void addOrder(Order);
+        virtual void receiveOrder(Order, bool);
 		bool canGarrison(Vehicle*);
 		void initLosLight();
 		void destroyLosLight();
@@ -187,6 +187,7 @@ namespace battleship{
 
 		std::vector<Player*> getSelectingPlayers();
         void removeOrder(int);
+		bool validateOrder(Order);
 		virtual void targetUnitsAutomatically();
 		virtual void reinit();
 		virtual void initProperties();

--- a/vehicle.cpp
+++ b/vehicle.cpp
@@ -46,17 +46,17 @@ namespace battleship{
 		pursuingTarget = false;
 	}
 
-	void Vehicle::addOrder(Order order){
+	void Vehicle::receiveOrder(Order order, bool add){
 		if(!(order.type == Order::TYPE::EJECT || order.type == Order::TYPE::LAUNCH)){
 			Order::Target targ = order.targets[0];
 			Vector3 targPos = (targ.unit ? targ.unit->getPos() : targ.pos);
 			preparePathpoints(order, targPos);
 
 			if(!pathPoints.empty())
-				orders.push_back(order);
+				Unit::receiveOrder(order, add);
 		}
 		else
-			orders.push_back(order);
+			Unit::receiveOrder(order, add);
 	}
 
     void Vehicle::turn(float angle) {

--- a/vehicle.h
+++ b/vehicle.h
@@ -28,7 +28,7 @@ namespace battleship{
 			void enterGarrisonable();
 			void halt();
 			void turn(float);
-			void addOrder(Order);
+			void receiveOrder(Order, bool);
 			void advance(float, MoveDir = MoveDir::FORW);
 			void addPathpoint(vb01::Vector3);
 			void removePathpoint(int = 0);


### PR DESCRIPTION
Prevented units from taking wrong orders. To test:
- attempt to order units to eject without garrison slots
- attempt to order units without weapons to attack
- attempt to order structures to move
- attempt to order non-engineers to hack