### PR TITLE
imp-156-adjust-sub-depth

### DIFF
--- a/Assets/Scripts/Core/options.lua
+++ b/Assets/Scripts/Core/options.lua
@@ -12,7 +12,7 @@ mappings = {
 		{bind = 8, trigger = 313, action = false, bindType = 2, inOptions = false},
 		{bind = 9, trigger = 310, action = false, bindType = 2, inOptions = false},
 		{bind = 10, trigger = 311, action = false, bindType = 2, inOptions = false},
-		{bind = 11, trigger = 1, action = true, bindType = 1, inOptions = false},
+		{bind = 11, trigger = 2, action = true, bindType = 1, inOptions = false},
 		{bind = 12, trigger = 0, action = true, bindType = 1, inOptions = true},
 		{bind = 13, trigger = 1, action = true, bindType = 1, inOptions = true},
 		{bind = 14, trigger = 72, action = true, bindType = 0, inOptions = true},

--- a/Assets/Scripts/Core/options.lua
+++ b/Assets/Scripts/Core/options.lua
@@ -22,7 +22,7 @@ mappings = {
 		{bind = 18, trigger = 340, action = true, bindType = 0, inOptions = true},
 		{bind = 19, trigger = 80, action = true, bindType = 0, inOptions = true},
 		{bind = 20, trigger = 76, action = true, bindType = 0, inOptions = true},
-		{bind = 21, trigger = 83, action = true, bindType = 0, inOptions = true},
+		{bind = 21, trigger = 32, action = true, bindType = 0, inOptions = true},
 		{bind = 22, trigger = 48, action = true, bindType = 0, inOptions = true},
 		{bind = 23, trigger = 49, action = true, bindType = 0, inOptions = true},
 		{bind = 24, trigger = 50, action = true, bindType = 0, inOptions = true},

--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -171,20 +171,18 @@ namespace battleship{
 				}
 
 			selectingDestOrient = true;
-			fc->setPlacingOnSurface(true);
 			fc->setRotating(true);
 		}
 		else if(selectingDestOrient && !orderMouseClicked){
 			selectingDestOrient = false;
 
-			fc->setPlacingOnSurface(false);
-			fc->setRotating(false);
+			fc->toggleFrameTransformations(false, false, false);
 			fc->removeGameObjectFrames();
 		}
 
         renderUnits();
 
-		if(fc->isPlacingOnSurface())
+		if(fc->isRotating() || fc->isPlacingOnSurface() || fc->isPlacingVertically())
 			fc->update();
 
 		CameraController *camCtr = CameraController::getSingleton();
@@ -221,8 +219,7 @@ namespace battleship{
 		mainPlayer->deselectUnits();
 		GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 		ufCtr->removeGameObjectFrames();
-		ufCtr->setPlacingOnSurface(false);
-		ufCtr->setRotating(false);
+		ufCtr->toggleFrameTransformations(false, false, false);
 
 		unitGuiScreen = "";
 		ConcreteGuiManager::getSingleton()->readLuaScreenScript("activeGameState.lua");
@@ -428,7 +425,15 @@ namespace battleship{
 
 	//TODO fix ejectable unit selection with multiple transports selected
     void ActiveGameState::issueOrder(Order::TYPE type, vector<Order::Target> targets, bool addOrder) {
-		Vector3 destDir = (selectingDestOrient ? GameObjectFrameController::getSingleton()->getGameObjectFrame(0).getDirVec() : Vector3::VEC_ZERO);
+		depth = 1;
+		Vector3 destDir =  Vector3::VEC_ZERO;
+		
+		if(selectingDestOrient){
+			GameObjectFrame &objFrame = GameObjectFrameController::getSingleton()->getGameObjectFrame(0);
+			destDir = objFrame.getDirVec();
+			targets[0].pos = objFrame.getPos();
+		}
+
 		mainPlayer->issueOrder(type, destDir, targets, addOrder);
 		this->targets.clear();
     }
@@ -492,8 +497,7 @@ namespace battleship{
 					quad->setSize(Vector3::VEC_ZERO);
 					quad->updateVerts(quad->getMeshBase());
 
-					ufCtr->setPlacingOnSurface(false);
-					ufCtr->setRotating(false);
+					ufCtr->toggleFrameTransformations(false, false, false);
 					ufCtr->removeGameObjectFrames();
                 }
 
@@ -563,7 +567,6 @@ namespace battleship{
 							issueOrder(Order::TYPE::MOVE, targets, shiftPressed);
 						}
 					}
-
 				}
 
                 break;
@@ -596,8 +599,7 @@ namespace battleship{
 					break;
 				}
 			case Bind::SHIFT_SUB_DEPTH:
-				ufCtr->setPlacingVertically(isPressed);
-				ufCtr->setRotating(false);
+				ufCtr->toggleFrameTransformations(false, false, isPressed);
                 break;
 			case Bind::ZOOM_IN:
                 if (zooms > -NUM_MAX_ZOOMS) {
@@ -674,9 +676,9 @@ namespace battleship{
 
                 break;
 			case Bind::DESELECT_STRUCTURE:
-				ufCtr->removeGameObjectFrames();
-				ufCtr->setPlacingOnSurface(false);
 				buildableStructSelected = false;
+				ufCtr->toggleFrameTransformations(false, false, false);
+				ufCtr->removeGameObjectFrames();
 				break;
         }
     }

--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -170,20 +170,21 @@ namespace battleship{
 					fc->placeGameObjectFrame(fc->getNumGameObjectFrames() - 1, targets[0].pos, selectedUnits[i]->getWidth(), selectedUnits[i]->getLength());
 				}
 
-			fc->setRotatingFrames(true);
 			selectingDestOrient = true;
+			fc->setPlacingOnSurface(true);
+			fc->setRotating(true);
 		}
 		else if(selectingDestOrient && !orderMouseClicked){
 			selectingDestOrient = false;
 
-			fc->setPlacingFrames(false);
-			fc->setRotatingFrames(false);
+			fc->setPlacingOnSurface(false);
+			fc->setRotating(false);
 			fc->removeGameObjectFrames();
 		}
 
         renderUnits();
 
-		if(fc->isPlacingFrames())
+		if(fc->isPlacingOnSurface())
 			fc->update();
 
 		CameraController *camCtr = CameraController::getSingleton();
@@ -220,8 +221,8 @@ namespace battleship{
 		mainPlayer->deselectUnits();
 		GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 		ufCtr->removeGameObjectFrames();
-		ufCtr->setPlacingFrames(false);
-		ufCtr->setRotatingFrames(false);
+		ufCtr->setPlacingOnSurface(false);
+		ufCtr->setRotating(false);
 
 		unitGuiScreen = "";
 		ConcreteGuiManager::getSingleton()->readLuaScreenScript("activeGameState.lua");
@@ -441,53 +442,8 @@ namespace battleship{
 		Map *map = Map::getSingleton();
 		vector<RayCaster::CollisionResult> results = map->raycastTerrain(camPos, rayDir, true);
 
-		if(!results.empty()){
-			GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
-
-			for(Unit *u : mainPlayer->getSelectedUnits()){
-				Vector3 pos = u->getPos();
-				Node *nodeParent = map->getNodeParent();
-
-				if(u->getType() == UnitType::UNDERWATER && nodeParent->getNumChildren() > 0){
-					Vector3 cellSize = map->getCellSize(), waterBodyPos;
-					bool inWater = false;
-
-					for(int i = 1; i < nodeParent->getNumChildren(); i++){
-						Vector3 wPos = nodeParent->getChild(i)->getPosition();
-						Vector3 wSize = ((Quad*)nodeParent->getChild(i)->getMesh(0))->getSize();
-						
-						if(fabs(wPos.x - pos.x) < .5 * wSize.x && fabs(wPos.z - pos.z) < .5 * wSize.y){
-							waterBodyPos = wPos;
-							inWater = true;
-							break;
-						}
-					}
-
-					if(inWater){
-						vector<RayCaster::CollisionResult> res = map->raycastTerrain(
-								Vector3(results[0].pos.x, 100, results[0].pos.z), 
-								-Vector3::VEC_J,
-								false
-						);
-
-						vector<Map::Cell> &cells = map->getCells();
-						int cid = map->getCellId(results[0].pos, false);
-						int numSubmarineCells = cells[cid].underWaterCellIds.size();
-						float maxDepth = cells[cid].pos.y;
-						float minDepth = (numSubmarineCells > 0 ? cells[cells[cid].underWaterCellIds[numSubmarineCells - 1]].pos.y : maxDepth) - .5 * cellSize.y;
-
-						float newDepth = res[0].pos.y + depth * (waterBodyPos.y - res[0].pos.y);
-
-						if(newDepth < minDepth) newDepth = minDepth;
-						else if(newDepth > maxDepth) newDepth = maxDepth;
-
-						results[0].pos.y = newDepth;
-					}
-				}
-			}
-
+		if(!results.empty())
 			targets.push_back(Order::Target(nullptr, results[0].pos));
-		}
     }
 
 	void ActiveGameState::enableUnitState(Unit::State state){
@@ -536,8 +492,8 @@ namespace battleship{
 					quad->setSize(Vector3::VEC_ZERO);
 					quad->updateVerts(quad->getMeshBase());
 
-					ufCtr->setPlacingFrames(false);
-					ufCtr->setRotatingFrames(false);
+					ufCtr->setPlacingOnSurface(false);
+					ufCtr->setRotating(false);
 					ufCtr->removeGameObjectFrames();
                 }
 
@@ -556,7 +512,7 @@ namespace battleship{
 						
 							if(controlPressed || (targets[0].unit && targets[0].unit->getPlayer()->getTeam() != mainPlayer->getTeam()))
 								type = Order::TYPE::ATTACK;
-							else if(ufCtr->isPlacingFrames() && !selectingDestOrient)
+							else if(ufCtr->isPlacingOnSurface() && !selectingDestOrient)
 								type = Order::TYPE::BUILD;
 						
 							issueOrder(type, targets, shiftPressed);
@@ -587,7 +543,7 @@ namespace battleship{
                     		castRayToTerrain();
 							issueOrder(Order::TYPE::ATTACK, targets, shiftPressed);
 						}
-						else if(selectedUnits[0]->getUnitClass() == UnitClass::ENGINEER && ufCtr->isPlacingFrames()){
+						else if(selectedUnits[0]->getUnitClass() == UnitClass::ENGINEER && ufCtr->isPlacingOnSurface()){
                     		castRayToTerrain();
 							GameObjectFrame gmObjFr = ufCtr->getGameObjectFrame(0);
 
@@ -639,7 +595,9 @@ namespace battleship{
 
 					break;
 				}
-			case Bind::TOGGLE_SUB:
+			case Bind::SHIFT_SUB_DEPTH:
+				ufCtr->setPlacingVertically(isPressed);
+				ufCtr->setRotating(false);
                 break;
 			case Bind::ZOOM_IN:
                 if (zooms > -NUM_MAX_ZOOMS) {
@@ -656,7 +614,7 @@ namespace battleship{
                 }
                 break;
 			case Bind::LOOK_AROUND:
-				if(!ufCtr->isPlacingFrames())
+				if(!ufCtr->isPlacingOnSurface())
 					CameraController::getSingleton()->setLookingAround(isPressed);
                 break;
 			case Bind::HALT: 
@@ -667,18 +625,14 @@ namespace battleship{
 				//TODO reimplement submarine diving mechanic
 			case Bind::LEFT_CONTROL:
                 controlPressed = isPressed;
-				if(isPressed) depth -= 0.05;
                 break;
 			case Bind::LEFT_SHIFT:
 			{
         		shiftPressed = isPressed;
 
-				GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 				ufCtr->setPaintSelecting(shiftPressed);
 
 				if(isPressed){
-					depth += 0.05;
-
 					Vector3 startPos = Root::getSingleton()->getCamera()->getPosition();
 					vector<RayCaster::CollisionResult> results = Map::getSingleton()->raycastTerrain(startPos, (screenToSpace(getCursorPos()) - startPos).norm(), true);
 
@@ -721,7 +675,7 @@ namespace battleship{
                 break;
 			case Bind::DESELECT_STRUCTURE:
 				ufCtr->removeGameObjectFrames();
-				ufCtr->setPlacingFrames(false);
+				ufCtr->setPlacingOnSurface(false);
 				buildableStructSelected = false;
 				break;
         }
@@ -739,13 +693,19 @@ namespace battleship{
 					dirProj = Vector3(dirProj.x, 0, dirProj.z).norm();
 					CameraController::getSingleton()->orientCamera(Vector3(0, 1, 0).cross(dirProj), strength);
 				}
+				else if(ufCtr->isPlacingVertically()){
+					depth -= .2 * strength;
+
+					if(depth < 0) depth = 0;
+					else if(depth > 1) depth = 1;
+				}
 
 				break;
 			case Bind::LOOK_LEFT: 
 			case Bind::LOOK_RIGHT: 
 				if(camCtr->isLookingAround())
 					CameraController::getSingleton()->orientCamera(Vector3(0, 1, 0), strength);
-				else if(ufCtr->isRotatingFrames())
+				else if(ufCtr->isRotating())
 					ufCtr->rotateGameObjectFrames(100 * strength);
 
 				break;

--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -164,10 +164,11 @@ namespace battleship{
 		if(!selectingDestOrient && orderMouseClicked && !selectedUnits.empty() && getTime() - lastOrderMouseClicked > 100){
 			if(targets.empty()) castRayToTerrain();
 
-			for(int i = 0; i < selectedUnits.size(); i++){
-				fc->addGameObjectFrame(GameObjectFrame(selectedUnits[i]->getId(), GameObject::Type::UNIT));
-				fc->placeGameObjectFrame(fc->getNumGameObjectFrames() - 1, targets[0].pos, selectedUnits[i]->getWidth(), selectedUnits[i]->getLength());
-			}
+			if(!buildableStructSelected)
+				for(int i = 0; i < selectedUnits.size(); i++){
+					fc->addGameObjectFrame(GameObjectFrame(selectedUnits[i]->getId(), GameObject::Type::UNIT));
+					fc->placeGameObjectFrame(fc->getNumGameObjectFrames() - 1, targets[0].pos, selectedUnits[i]->getWidth(), selectedUnits[i]->getLength());
+				}
 
 			fc->setRotatingFrames(true);
 			selectingDestOrient = true;
@@ -597,6 +598,8 @@ namespace battleship{
 							targets[0].unit = buildStruct;
 
 							issueOrder(Order::TYPE::BUILD, targets, shiftPressed);
+
+							buildableStructSelected = false;
 						}
 						else if(!canSelect){
                     		if(targets.empty()) castRayToTerrain();
@@ -719,6 +722,7 @@ namespace battleship{
 			case Bind::DESELECT_STRUCTURE:
 				ufCtr->removeGameObjectFrames();
 				ufCtr->setPlacingFrames(false);
+				buildableStructSelected = false;
 				break;
         }
     }

--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -162,13 +162,15 @@ namespace battleship{
 		GameObjectFrameController *fc = GameObjectFrameController::getSingleton();
 
 		if(!selectingDestOrient && orderMouseClicked && !selectedUnits.empty() && getTime() - lastOrderMouseClicked > 100){
-			selectingDestOrient = true;
+			if(targets.empty()) castRayToTerrain();
 
-			fc->setPlacingFrames(true);
+			for(int i = 0; i < selectedUnits.size(); i++){
+				fc->addGameObjectFrame(GameObjectFrame(selectedUnits[i]->getId(), GameObject::Type::UNIT));
+				fc->placeGameObjectFrame(fc->getNumGameObjectFrames() - 1, targets[0].pos, selectedUnits[i]->getWidth(), selectedUnits[i]->getLength());
+			}
+
 			fc->setRotatingFrames(true);
-
-			for(Unit *unit : selectedUnits)
-				fc->addGameObjectFrame(GameObjectFrame(unit->getId(), GameObject::Type::UNIT));
+			selectingDestOrient = true;
 		}
 		else if(selectingDestOrient && !orderMouseClicked){
 			selectingDestOrient = false;
@@ -597,7 +599,8 @@ namespace battleship{
 							issueOrder(Order::TYPE::BUILD, targets, shiftPressed);
 						}
 						else if(!canSelect){
-                    		castRayToTerrain();
+                    		if(targets.empty()) castRayToTerrain();
+
 							issueOrder(Order::TYPE::MOVE, targets, shiftPressed);
 						}
 					}

--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -149,7 +149,7 @@ namespace battleship{
 
 		float eps = .01;
 
-		if(!isSelectionBox && leftMouseClicked && (fabs(clickPoint.x - cursorPos.x) > eps || fabs(clickPoint.y - cursorPos.y) > eps) && getTime() - lastLeftMouseClicked > 10)
+		if(!isSelectionBox && selectMouseClicked && (fabs(clickPoint.x - cursorPos.x) > eps || fabs(clickPoint.y - cursorPos.y) > eps) && getTime() - lastSelectMouseClicked > 10)
 			isSelectionBox = true;
 		else if (isSelectionBox)
 			updateDragBox();
@@ -161,7 +161,7 @@ namespace battleship{
 		vector<Unit*> selectedUnits = mainPlayer->getSelectedUnits();
 		GameObjectFrameController *fc = GameObjectFrameController::getSingleton();
 
-		if(!selectingDestOrient && leftMouseClicked && !selectedUnits.empty() && getTime() - lastLeftMouseClicked > 100){
+		if(!selectingDestOrient && orderMouseClicked && !selectedUnits.empty() && getTime() - lastOrderMouseClicked > 100){
 			selectingDestOrient = true;
 
 			fc->setPlacingFrames(true);
@@ -169,6 +169,13 @@ namespace battleship{
 
 			for(Unit *unit : selectedUnits)
 				fc->addGameObjectFrame(GameObjectFrame(unit->getId(), GameObject::Type::UNIT));
+		}
+		else if(selectingDestOrient && !orderMouseClicked){
+			selectingDestOrient = false;
+
+			fc->setPlacingFrames(false);
+			fc->setRotatingFrames(false);
+			fc->removeGameObjectFrames();
 		}
 
         renderUnits();
@@ -211,6 +218,7 @@ namespace battleship{
 		GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 		ufCtr->removeGameObjectFrames();
 		ufCtr->setPlacingFrames(false);
+		ufCtr->setRotatingFrames(false);
 
 		unitGuiScreen = "";
 		ConcreteGuiManager::getSingleton()->readLuaScreenScript("activeGameState.lua");
@@ -486,94 +494,27 @@ namespace battleship{
 			unit->setState(state);
 	}
     
-	//TODO only allow appropriate orders for units
     void ActiveGameState::onAction(int bind, bool isPressed) {
 		GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 
 		if(!ConcreteGuiManager::getSingleton()->findClickedButtons().empty())
 			return;
 
+		vector<Unit*> selectedUnits = mainPlayer->getSelectedUnits();
+
         switch((Bind)bind){
 			case Bind::DRAG_BOX: 
-				leftMouseClicked = isPressed;
+				selectMouseClicked = isPressed;
 
 				if(isPressed){
 					clickPoint = getCursorPos();
-					lastLeftMouseClicked = getTime();
+					lastSelectMouseClicked = getTime();
 				}
 				else{
-					int numSelectedUnits = mainPlayer->getNumSelectedUnits();
+					if(!shiftPressed) deselectUnits();
 
-                    if(numSelectedUnits > 0){
-						if(selectingPatrolPoints){
-                    		castRayToTerrain();
-
-							if(!(targets.empty() || selectingPatrolPoints)){
-								Order::TYPE type = Order::TYPE::MOVE;
-							
-								if(controlPressed || (targets[0].unit && targets[0].unit->getPlayer()->getTeam() != mainPlayer->getTeam()))
-									type = Order::TYPE::ATTACK;
-								else if(ufCtr->isPlacingFrames() && !selectingDestOrient)
-									type = Order::TYPE::BUILD;
-							
-								issueOrder(type, targets, shiftPressed);
-							}
-						}
-						else if(!(selectingDestOrient || isSelectionBox)){
-							bool canSelect = canSelectHoveredOnGameObj();
-							bool ownGameObj = (gameObjHoveredOn && gameObjHoveredOn->getPlayer()->getTeam() == mainPlayer->getTeam());
-
-							if(gameObjHoveredOn && gameObjHoveredOn->getType() == GameObject::Type::UNIT && ownGameObj && ((Unit*)gameObjHoveredOn)->getNumGarrisonSlots() > 0){
-								bool canGarrison = true;
-
-								for(int i = 0; i < mainPlayer->getNumSelectedUnits(); i++)
-									if(!((Unit*)gameObjHoveredOn)->canGarrison((Vehicle*)mainPlayer->getSelectedUnit(i))){
-										canGarrison = false;
-										break;
-									}
-
-								if(canGarrison)
-									issueOrder(Order::TYPE::GARRISON, vector<Order::Target>{Order::Target((Unit*)gameObjHoveredOn, gameObjHoveredOn->getPos())}, shiftPressed);
-							}
-							else if(gameObjHoveredOn && ownGameObj && ((Unit*)gameObjHoveredOn)->getUnitClass() == UnitClass::EXTRACTOR && !controlPressed){
-								issueOrder(Order::TYPE::SUPPLY, vector<Order::Target>{Order::Target((Unit*)gameObjHoveredOn)}, shiftPressed);
-							}
-							else if(gameObjHoveredOn && (controlPressed || (!ownGameObj && gameObjHoveredOn->getType() == GameObject::Type::UNIT)))
-								issueOrder(Order::TYPE::ATTACK, vector<Order::Target>{Order::Target((Unit*)gameObjHoveredOn, gameObjHoveredOn->getPos())}, shiftPressed);
-							else if(controlPressed && !gameObjHoveredOn){
-                    			castRayToTerrain();
-								issueOrder(Order::TYPE::ATTACK, targets, shiftPressed);
-							}
-							else if(ufCtr->isPlacingFrames() && !selectingDestOrient){
-                    			castRayToTerrain();
-								GameObjectFrame gmObjFr = ufCtr->getGameObjectFrame(0);
-
-								if(gmObjFr.status == GameObjectFrame::NOT_PLACEABLE)
-									return;
-
-								Unit *buildStruct = GameObjectFactory::createUnit(mainPlayer, gmObjFr.getId(), gmObjFr.getPos(), gmObjFr.getRot());
-								mainPlayer->addUnit(buildStruct);
-								targets[0].unit = buildStruct;
-
-								issueOrder(Order::TYPE::BUILD, targets, shiftPressed);
-							}
-							else if(canSelect){
-								if(!shiftPressed)
-									deselectUnits();
-
-								mainPlayer->selectUnit((Unit*)gameObjHoveredOn);
-							}
-							else if(!canSelect){
-                    			castRayToTerrain();
-								issueOrder(Order::TYPE::MOVE, targets, shiftPressed);
-							}
-						}
-					}
-					else if(numSelectedUnits == 0 && canSelectHoveredOnGameObj()){
-						if(!shiftPressed) deselectUnits();
-
+					if(canSelectHoveredOnGameObj())
 						mainPlayer->selectUnit((Unit*)gameObjHoveredOn);
-					}
 
 					selectingDestOrient = false;
 
@@ -598,6 +539,74 @@ namespace battleship{
                 }
 
                 break;
+			case Bind::ROTATE_OBJ_FRAME:
+				orderMouseClicked = isPressed;
+
+				if(isPressed)
+					lastOrderMouseClicked = getTime();
+				else if(!(isPressed || selectedUnits.empty())){
+					if(selectingPatrolPoints){
+                    	castRayToTerrain();
+
+						if(!(targets.empty() || selectingPatrolPoints)){
+							Order::TYPE type = Order::TYPE::MOVE;
+						
+							if(controlPressed || (targets[0].unit && targets[0].unit->getPlayer()->getTeam() != mainPlayer->getTeam()))
+								type = Order::TYPE::ATTACK;
+							else if(ufCtr->isPlacingFrames() && !selectingDestOrient)
+								type = Order::TYPE::BUILD;
+						
+							issueOrder(type, targets, shiftPressed);
+						}
+					}
+					else if(!isSelectionBox){
+						bool canSelect = canSelectHoveredOnGameObj();
+						bool ownGameObj = (gameObjHoveredOn && gameObjHoveredOn->getPlayer()->getTeam() == mainPlayer->getTeam());
+
+						if(gameObjHoveredOn && gameObjHoveredOn->getType() == GameObject::Type::UNIT && ownGameObj && ((Unit*)gameObjHoveredOn)->getNumGarrisonSlots() > 0){
+							bool canGarrison = true;
+
+							for(int i = 0; i < mainPlayer->getNumSelectedUnits(); i++)
+								if(!((Unit*)gameObjHoveredOn)->canGarrison((Vehicle*)mainPlayer->getSelectedUnit(i))){
+									canGarrison = false;
+									break;
+								}
+
+							if(canGarrison)
+								issueOrder(Order::TYPE::GARRISON, vector<Order::Target>{Order::Target((Unit*)gameObjHoveredOn, gameObjHoveredOn->getPos())}, shiftPressed);
+						}
+						else if(gameObjHoveredOn && ownGameObj && ((Unit*)gameObjHoveredOn)->getUnitClass() == UnitClass::EXTRACTOR && !controlPressed){
+							issueOrder(Order::TYPE::SUPPLY, vector<Order::Target>{Order::Target((Unit*)gameObjHoveredOn)}, shiftPressed);
+						}
+						else if(gameObjHoveredOn && (controlPressed || (!ownGameObj && gameObjHoveredOn->getType() == GameObject::Type::UNIT)))
+							issueOrder(Order::TYPE::ATTACK, vector<Order::Target>{Order::Target((Unit*)gameObjHoveredOn, gameObjHoveredOn->getPos())}, shiftPressed);
+						else if(controlPressed && !gameObjHoveredOn){
+                    		castRayToTerrain();
+							issueOrder(Order::TYPE::ATTACK, targets, shiftPressed);
+						}
+						else if(selectedUnits[0]->getUnitClass() == UnitClass::ENGINEER && ufCtr->isPlacingFrames()){
+                    		castRayToTerrain();
+							GameObjectFrame gmObjFr = ufCtr->getGameObjectFrame(0);
+
+							if(gmObjFr.status == GameObjectFrame::NOT_PLACEABLE) return;
+
+							Unit *buildStruct = GameObjectFactory::createUnit(mainPlayer, gmObjFr.getId(), gmObjFr.getPos(), gmObjFr.getRot());
+							mainPlayer->addUnit(buildStruct);
+							targets[0].unit = buildStruct;
+
+							issueOrder(Order::TYPE::BUILD, targets, shiftPressed);
+						}
+						else if(!canSelect){
+                    		castRayToTerrain();
+							issueOrder(Order::TYPE::MOVE, targets, shiftPressed);
+						}
+					}
+
+				}
+
+                break;
+			case Bind::MOVE_CAMERA:
+				break;
 			case Bind::ENABLE_CHASE_STATE:
 				if(isPressed) enableUnitState(Unit::State::CHASE);
 				break;
@@ -607,10 +616,6 @@ namespace battleship{
 			case Bind::ENABLE_HOLD_FIRE_STATE:
 				if(isPressed) enableUnitState(Unit::State::HOLD_FIRE);
 				break;
-			case Bind::DESELECT:
-				if(ufCtr->isPlacingFrames()) ufCtr->setRotatingFrames(isPressed);
-                if (!isPressed) deselectUnits();
-                break;
 			case Bind::EJECT_GARRISON:
 				if(isPressed) issueOrder(Order::TYPE::EJECT, vector<Order::Target>{}, shiftPressed);
 				break;
@@ -640,7 +645,7 @@ namespace battleship{
 			case Bind::ZOOM_OUT:
                 if (zooms < NUM_MAX_ZOOMS) {
 					Camera *cam = Root::getSingleton()->getCamera();
-                    cam->setPosition(cam->getPosition() - (cam->getDirection().norm().norm() * .5f));
+                    cam->setPosition(cam->getPosition() - (cam->getDirection().norm() * .5f));
                     zooms++;
                 }
                 break;

--- a/activeGameState.h
+++ b/activeGameState.h
@@ -36,6 +36,7 @@ namespace battleship{
         inline std::vector<Unit*>& getUnitGroup(int i){return unitGroups[i];}
 		inline void setBuildableStructSelected(bool bss){this->buildableStructSelected = bss;}
 		inline bool isBuildableStructSelected(){return buildableStructSelected;}
+		inline float getDepth(){return depth;}
     private:
 		enum CursorState{
 			NORMAL,

--- a/activeGameState.h
+++ b/activeGameState.h
@@ -34,6 +34,8 @@ namespace battleship{
 		inline std::vector<vb01Gui::Button*> getButtons(){return buttons;}
         inline Player* getPlayer(){return mainPlayer;}
         inline std::vector<Unit*>& getUnitGroup(int i){return unitGroups[i];}
+		inline void setBuildableStructSelected(bool bss){this->buildableStructSelected = bss;}
+		inline bool isBuildableStructSelected(){return buildableStructSelected;}
     private:
 		enum CursorState{
 			NORMAL,
@@ -69,11 +71,18 @@ namespace battleship{
         std::vector<Unit*> unitGroups[9];
 		std::vector<Order::Target> targets;
 		std::vector<vb01Gui::Button*> buttons;
-        bool isSelectionBox = false, shiftPressed = false, controlPressed = false, leftMouseClicked = false, selectingPatrolPoints = false, selectingDestOrient = false;
+        bool isSelectionBox = false;
+		bool shiftPressed = false;
+		bool controlPressed = false;
+		bool selectMouseClicked = false;
+		bool orderMouseClicked = false;
+		bool buildableStructSelected = false;
+		bool selectingPatrolPoints = false;
+		bool selectingDestOrient = false;
         int playerId, zooms = 0;
 	   	const int NUM_MAX_ZOOMS = 10;
 		float depth = 1;
-		vb01::s64 lastLeftMouseClicked = 0;
+		vb01::s64 lastSelectMouseClicked = 0, lastOrderMouseClicked = 0;
 		vb01::Node *cursorNode = nullptr;
 		vb01::Texture *pointerTex = nullptr, *attackTex = nullptr, *garrisonTex = nullptr;
     };

--- a/binds.h
+++ b/binds.h
@@ -16,7 +16,7 @@ namespace battleship{
 		LOOK_RIGHT,
 		LOOK_AROUND,
 		DRAG_BOX,
-		DESELECT,
+		ROTATE_OBJ_FRAME,
 		HALT,
 		ZOOM_IN,
 		ZOOM_OUT,
@@ -54,7 +54,8 @@ namespace battleship{
 		ENABLE_CHASE_STATE,
 		ENABLE_STAND_GROUND_STATE,
 		ENABLE_HOLD_FIRE_STATE,
-		HACK
+		HACK,
+		MOVE_CAMERA
 	};
 }
 

--- a/binds.h
+++ b/binds.h
@@ -24,7 +24,7 @@ namespace battleship{
 		LEFT_SHIFT,
 		SELECT_PATROL_POINTS,
 		LAUNCH,
-		TOGGLE_SUB,
+		SHIFT_SUB_DEPTH,
 		GROUP_0,
 		GROUP_1,
 		GROUP_2,

--- a/buildButton.cpp
+++ b/buildButton.cpp
@@ -27,8 +27,7 @@ namespace battleship{
 		if(builder->getBuildableUnit(slotId).buildable){
 			GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 			ufCtr->addGameObjectFrame(GameObjectFrame(builder->getBuildableUnit(slotId).id, GameObject::Type::UNIT));
-			ufCtr->setPlacingFrames(true);
-
+			ufCtr->setPlacingOnSurface(true);
 			activeState->setBuildableStructSelected(true);
 		}
 	}

--- a/buildButton.cpp
+++ b/buildButton.cpp
@@ -28,6 +28,8 @@ namespace battleship{
 			GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 			ufCtr->addGameObjectFrame(GameObjectFrame(builder->getBuildableUnit(slotId).id, GameObject::Type::UNIT));
 			ufCtr->setPlacingFrames(true);
+
+			activeState->setBuildableStructSelected(true);
 		}
 	}
 }

--- a/defConfigs.h
+++ b/defConfigs.h
@@ -97,7 +97,7 @@ namespace battleship{
   		        Bind::LEFT_SHIFT,
   		        Bind::SELECT_PATROL_POINTS,
   		        Bind::LAUNCH,
-  		        Bind::TOGGLE_SUB,
+  		        Bind::SHIFT_SUB_DEPTH,
   		        Bind::GROUP_0,
   		        Bind::GROUP_1,
   		        Bind::GROUP_2,

--- a/defConfigs.h
+++ b/defConfigs.h
@@ -88,7 +88,8 @@ namespace battleship{
   		    },
   		    {
   		        Bind::DRAG_BOX,
-  		        Bind::DESELECT,
+				Bind::MOVE_CAMERA,
+  		        Bind::ROTATE_OBJ_FRAME,
 				Bind::HALT,
   		        Bind::ZOOM_IN,
   		        Bind::ZOOM_OUT,

--- a/gameObjectFrameController.cpp
+++ b/gameObjectFrameController.cpp
@@ -1,6 +1,7 @@
 #include <solUtil.h>
 
 #include "gameObjectFrameController.h"
+#include "activeGameState.h"
 #include "resourceDeposit.h"
 #include "defConfigs.h"
 #include "player.h"
@@ -11,9 +12,11 @@
 
 #include <material.h>
 #include <meshData.h>
-#include <mesh.h>
+#include <quad.h>
 #include <model.h>
 #include <root.h>
+
+#include <stateManager.h>
 
 #include <string>
 
@@ -116,29 +119,77 @@ namespace battleship{
 		for(GameObjectFrame &frame : gameObjectFrames)
 			frame.update();
 
+		Map *map = Map::getSingleton();
 		Vector3 startPos = Root::getSingleton()->getCamera()->getPosition();
-		vector<RayCaster::CollisionResult> results = Map::getSingleton()->raycastTerrain(startPos, (screenToSpace(getCursorPos()) - startPos).norm(), true);
+		Vector3 endPos = screenToSpace(getCursorPos());
+		vector<RayCaster::CollisionResult> results = map->raycastTerrain(startPos, (endPos - startPos).norm(), true);
 
 		if(results.empty()) return;
 
-		Vector3 newPos, rowEnd;
-		sol::table sizeTable = generateView()[gameObjectFrames[0].getGameObjTableName()][gameObjectFrames[0].getId() + 1]["size"]; 
-    	float width = sizeTable["x"], length = sizeTable["z"];
+    	float width, length;
 
-		if(paintSelecting)
+		if(paintSelecting){
+			sol::table sizeTable = generateView()[gameObjectFrames[0].getGameObjTableName()][gameObjectFrames[0].getId() + 1]["size"]; 
+    		width = sizeTable["x"], length = sizeTable["z"];
 			paintSelect(results[0].pos, width, length);
-		else if(!(paintSelecting || rotatingStructure))
-			newPos = results[0].pos;
+		}
+
+		if(placingVertically){
+			if(!minDepthCalculated){
+				placementPos = results[0].pos;
+
+				Node *nodeParent = map->getNodeParent();
+				Vector3 cellSize = map->getCellSize(), waterBodyPos;
+				bool inWater = false;
+		
+				for(int i = 1; i < nodeParent->getNumChildren(); i++){
+					Vector3 wPos = nodeParent->getChild(i)->getPosition();
+					Vector3 wSize = ((Quad*)nodeParent->getChild(i)->getMesh(0))->getSize();
+					
+					if(fabs(wPos.x - endPos.x) < .5 * wSize.x && fabs(wPos.z - endPos.z) < .5 * wSize.y){
+						waterBodyPos = wPos;
+						inWater = true;
+						break;
+					}
+				}
+		
+				if(inWater){
+					vector<RayCaster::CollisionResult> res = map->raycastTerrain(
+							Vector3(endPos.x, 100, endPos.z), 
+							-Vector3::VEC_J,
+							false
+					);
+		
+					vector<Map::Cell> &cells = map->getCells();
+					int cid = map->getCellId(placementPos, false);
+					int numSubmarineCells = cells[cid].underWaterCellIds.size();
+					maxDepth = cells[cid].pos.y;
+					minDepth = (numSubmarineCells > 0 ? cells[cells[cid].underWaterCellIds[numSubmarineCells - 1]].pos.y : maxDepth) - .5 * cellSize.y;
+					minDepthCalculated = true;
+				}
+			}
+			else{
+				ActiveGameState *activeState = (ActiveGameState*)(GameManager::getSingleton()->getStateManager()->getAppStateByType((int)AppStateType::ACTIVE_STATE));
+				float newDepth = minDepth + activeState->getDepth() * (maxDepth - minDepth);
+				placementPos.y = newDepth;
+			}
+		}
+		else{
+			minDepthCalculated = false;
+
+			if(placingOnSurface)
+				placementPos = results[0].pos;
+		}
 
 		for(int i = 0; i < gameObjectFrames.size(); i++){
 			if(paintSelecting){
 				float hypothenuse = sqrt(width * width + length * length);
 				Vector3 dir = (results[0].pos - paintSelectRowStart).norm(); 
-				newPos = paintSelectRowStart + dir * hypothenuse * i;
+				placementPos = paintSelectRowStart + dir * hypothenuse * i;
 			}
 
-
-			if(!rotatingStructure) placeGameObjectFrame(i, newPos, width, length);
+			if(!rotating && (placingOnSurface || placingVertically))
+				placeGameObjectFrame(i, placementPos, width, length);
 		}
 	}
 

--- a/gameObjectFrameController.cpp
+++ b/gameObjectFrameController.cpp
@@ -83,6 +83,7 @@ namespace battleship{
 
 	//TODO implement terrain evenness check
 	//TODO factor out literal values
+	//TODO fix which unit frames light green or red
 	void GameObjectFrameController::placeGameObjectFrame(int id, Vector3 newPos, float width, float length){
 		Map *map = Map::getSingleton();
 		MeshData meshData = map->getNodeParent()->getChild(0)->getMesh(0)->getMeshBase();
@@ -90,6 +91,7 @@ namespace battleship{
 		int numVerts = 3 * meshData.numTris;
 
 		float maxUnevenness = .5, unevenness = 0;
+		bool placeable = true;
 
 		for(int i = 0; i < numVerts; i++){
 			float diffX = fabs(newPos.x - verts[i].pos->x);
@@ -99,30 +101,41 @@ namespace battleship{
 			if(diffX < 0.5 * width && diffZ < 0.5 * length && diffY > unevenness){
 				unevenness = diffY;
 
-				if(unevenness > maxUnevenness)
+				if(unevenness > maxUnevenness){
+					placeable = false;
 					break;
+				}
 			}
 		}
 
 		GameObjectFrame &s = gameObjectFrames[id];
 		s.placeAt(newPos);
 
-		s.status = (unevenness < maxUnevenness ? GameObjectFrame::PLACEABLE : GameObjectFrame::NOT_PLACEABLE);
 		snapToObj(s, GameObject::Type::UNIT, 20, 3);
 
+		Vector4 color;
+
+		if(placeable){
+			s.status = GameObjectFrame::PLACEABLE;
+			color = Vector4(0, 1, 0, 1);
+		}
+		else{
+			s.status = GameObjectFrame::NOT_PLACEABLE;
+			color = Vector4(1, 0, 0, 1);
+		}
+
 		Material *mat = s.getModel()->getMaterial();
-		Vector4 color = (s.status == GameObjectFrame::NOT_PLACEABLE ? Vector4(1, 0, 0, 1) : Vector4(0, 1, 0, 1));
 		mat->setVec4Uniform("diffuseColor", color);
 	}
 
-	void GameObjectFrameController::update(){
+	void GameObjectFrameController::updatePlacement(){
 		for(GameObjectFrame &frame : gameObjectFrames)
 			frame.update();
 
 		Map *map = Map::getSingleton();
 		Vector3 startPos = Root::getSingleton()->getCamera()->getPosition();
 		Vector3 endPos = screenToSpace(getCursorPos());
-		vector<RayCaster::CollisionResult> results = map->raycastTerrain(startPos, (endPos - startPos).norm(), true);
+		vector<RayCaster::CollisionResult> results = map->raycastTerrain(startPos, (screenToSpace(getCursorPos()) - startPos).norm(), true);
 
 		if(results.empty()) return;
 
@@ -146,27 +159,27 @@ namespace battleship{
 					Vector3 wPos = nodeParent->getChild(i)->getPosition();
 					Vector3 wSize = ((Quad*)nodeParent->getChild(i)->getMesh(0))->getSize();
 					
-					if(fabs(wPos.x - endPos.x) < .5 * wSize.x && fabs(wPos.z - endPos.z) < .5 * wSize.y){
+					if(fabs(wPos.x - placementPos.x) < .5 * wSize.x && fabs(wPos.z - placementPos.z) < .5 * wSize.y){
 						waterBodyPos = wPos;
 						inWater = true;
 						break;
 					}
 				}
+
+				if(!inWater) return;
 		
-				if(inWater){
-					vector<RayCaster::CollisionResult> res = map->raycastTerrain(
-							Vector3(endPos.x, 100, endPos.z), 
-							-Vector3::VEC_J,
-							false
-					);
+				vector<RayCaster::CollisionResult> res = map->raycastTerrain(
+					Vector3(placementPos.x, 100, placementPos.z), 
+					-Vector3::VEC_J,
+					false
+				);
 		
-					vector<Map::Cell> &cells = map->getCells();
-					int cid = map->getCellId(placementPos, false);
-					int numSubmarineCells = cells[cid].underWaterCellIds.size();
-					maxDepth = cells[cid].pos.y;
-					minDepth = (numSubmarineCells > 0 ? cells[cells[cid].underWaterCellIds[numSubmarineCells - 1]].pos.y : maxDepth) - .5 * cellSize.y;
-					minDepthCalculated = true;
-				}
+				vector<Map::Cell> &cells = map->getCells();
+				int cid = map->getCellId(placementPos, false);
+				int numSubmarineCells = cells[cid].underWaterCellIds.size();
+				maxDepth = cells[cid].pos.y;
+				minDepth = (numSubmarineCells > 0 ? cells[cells[cid].underWaterCellIds[numSubmarineCells - 1]].pos.y : maxDepth) - .5 * cellSize.y;
+				minDepthCalculated = true;
 			}
 			else{
 				ActiveGameState *activeState = (ActiveGameState*)(GameManager::getSingleton()->getStateManager()->getAppStateByType((int)AppStateType::ACTIVE_STATE));
@@ -174,12 +187,8 @@ namespace battleship{
 				placementPos.y = newDepth;
 			}
 		}
-		else{
-			minDepthCalculated = false;
-
-			if(placingOnSurface)
-				placementPos = results[0].pos;
-		}
+		else if(placingOnSurface)
+			placementPos = results[0].pos;
 
 		for(int i = 0; i < gameObjectFrames.size(); i++){
 			if(paintSelecting){
@@ -191,6 +200,12 @@ namespace battleship{
 			if(!rotating && (placingOnSurface || placingVertically))
 				placeGameObjectFrame(i, placementPos, width, length);
 		}
+	}
+
+	void GameObjectFrameController::update(){
+		updatePlacement();
+
+		if(!placingVertically) minDepthCalculated = false;
 	}
 
 	void GameObjectFrameController::removeGameObjectFrame(int i){

--- a/gameObjectFrameController.cpp
+++ b/gameObjectFrameController.cpp
@@ -52,6 +52,7 @@ namespace battleship{
 		}
 	}
 
+	//TODO specify what to snap the frame to
 	void GameObjectFrameController::snapToObj(GameObjectFrame &s, GameObject::Type type, int unitId, float maxDist){
 		if(s.getType() == GameObject::Type::UNIT && s.getId() == unitId){
 			s.status = GameObjectFrame::NOT_PLACEABLE;
@@ -101,9 +102,7 @@ namespace battleship{
 		}
 
 		GameObjectFrame &s = gameObjectFrames[id];
-
-		if(!rotatingStructure)
-			s.placeAt(newPos);
+		s.placeAt(newPos);
 
 		s.status = (unevenness < maxUnevenness ? GameObjectFrame::PLACEABLE : GameObjectFrame::NOT_PLACEABLE);
 		snapToObj(s, GameObject::Type::UNIT, 20, 3);
@@ -138,7 +137,8 @@ namespace battleship{
 				newPos = paintSelectRowStart + dir * hypothenuse * i;
 			}
 
-			placeGameObjectFrame(i, newPos, width, length);
+
+			if(!rotatingStructure) placeGameObjectFrame(i, newPos, width, length);
 		}
 	}
 

--- a/gameObjectFrameController.h
+++ b/gameObjectFrameController.h
@@ -34,10 +34,16 @@ namespace battleship{
 			inline bool isPlacingVertically(){return placingVertically;}
 			inline void setPlacingVertically(bool v){this->placingVertically = v;}
 			inline void setPaintSelectRowStart(vb01::Vector3 st){paintSelectRowStart = st;}
+			inline void toggleFrameTransformations(bool rot, bool pos, bool pv){
+				setRotating(rot);
+				setPlacingOnSurface(pos);
+				setPlacingVertically(pv);
+			}
 		private:
 			GameObjectFrameController(){}
 			void paintSelect(vb01::Vector3, float, float);
 			void snapToObj(GameObjectFrame&, GameObject::Type, int, float);
+			void updatePlacement();
 
 			std::vector<GameObjectFrame> gameObjectFrames;
 			vb01::Vector3 paintSelectRowStart, placementPos;

--- a/gameObjectFrameController.h
+++ b/gameObjectFrameController.h
@@ -21,6 +21,7 @@ namespace battleship{
 			void removeGameObjectFrame(int);
 			void removeGameObjectFrames();
 			void rotateGameObjectFrames(float);
+			void placeGameObjectFrame(int, vb01::Vector3, float, float);
 			inline int getNumGameObjectFrames(){return gameObjectFrames.size();}
 			inline void addGameObjectFrame(GameObjectFrame u){gameObjectFrames.push_back(u);}
 			inline GameObjectFrame& getGameObjectFrame(int i){return gameObjectFrames[i];}
@@ -34,7 +35,6 @@ namespace battleship{
 		private:
 			GameObjectFrameController(){}
 			void paintSelect(vb01::Vector3, float, float);
-			void placeGameObjectFrame(int, vb01::Vector3, float, float);
 			void snapToObj(GameObjectFrame&, GameObject::Type, int, float);
 
 			std::vector<GameObjectFrame> gameObjectFrames;

--- a/gameObjectFrameController.h
+++ b/gameObjectFrameController.h
@@ -25,12 +25,14 @@ namespace battleship{
 			inline int getNumGameObjectFrames(){return gameObjectFrames.size();}
 			inline void addGameObjectFrame(GameObjectFrame u){gameObjectFrames.push_back(u);}
 			inline GameObjectFrame& getGameObjectFrame(int i){return gameObjectFrames[i];}
-			inline bool isPlacingFrames(){return placingStructures;}
-			inline void setPlacingFrames(bool ps){placingStructures = ps;}
 			inline bool isPaintSelecting(){return paintSelecting;}
 			inline void setPaintSelecting(bool ps){paintSelecting = ps;}
-			inline bool isRotatingFrames(){return rotatingStructure;}
-			inline void setRotatingFrames(bool rs){rotatingStructure = rs;}
+			inline bool isRotating(){return rotating;}
+			inline void setRotating(bool rs){rotating = rs;}
+			inline bool isPlacingOnSurface(){return placingOnSurface;}
+			inline void setPlacingOnSurface(bool ps){placingOnSurface = ps;}
+			inline bool isPlacingVertically(){return placingVertically;}
+			inline void setPlacingVertically(bool v){this->placingVertically = v;}
 			inline void setPaintSelectRowStart(vb01::Vector3 st){paintSelectRowStart = st;}
 		private:
 			GameObjectFrameController(){}
@@ -38,8 +40,9 @@ namespace battleship{
 			void snapToObj(GameObjectFrame&, GameObject::Type, int, float);
 
 			std::vector<GameObjectFrame> gameObjectFrames;
-			vb01::Vector3 paintSelectRowStart, rowDir;
-	   		bool placingStructures = false, paintSelecting = false, rotatingStructure = false;
+			vb01::Vector3 paintSelectRowStart, placementPos;
+			float minDepth, maxDepth;
+	   		bool paintSelecting = false, rotating = false, placingOnSurface = false, placingVertically = false, minDepthCalculated = false;
 	};
 }
 

--- a/gameObjectListbox.cpp
+++ b/gameObjectListbox.cpp
@@ -16,6 +16,6 @@ namespace battleship{
 		GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 		GameObject::Type type = (unitListbox ? GameObject::Type::UNIT : GameObject::Type::RESOURCE_DEPOSIT);
 		ufCtr->addGameObjectFrame(GameObjectFrame(selectedOption, type));
-		ufCtr->setPlacingFrames(true);
+		ufCtr->setPlacingOnSurface(true);
 	}
 }

--- a/inGameAppState.cpp
+++ b/inGameAppState.cpp
@@ -106,7 +106,7 @@ namespace battleship{
     void InGameAppState::onAction(int bind, bool isPressed) {
         switch((Bind)bind){
 			case Bind::TOGGLE_MAIN_MENU: 
-            	if(isPressed && !GameObjectFrameController::getSingleton()->isPlacingFrames())
+            	if(isPressed && !GameObjectFrameController::getSingleton()->isPlacingOnSurface())
 					Game::getSingleton()->togglePause();
             break;
         }

--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -624,7 +624,7 @@ namespace battleship{
 
 		GameObjectFrameController *ufCtr = GameObjectFrameController::getSingleton();
 
-		if(ufCtr->isPlacingFrames())
+		if(ufCtr->isPlacingOnSurface())
 			ufCtr->update();
 	}
 
@@ -659,7 +659,7 @@ namespace battleship{
 
 		switch((Bind)bind){
 			case Bind::LOOK_AROUND:
-				if(ufCtr->isPlacingFrames()){
+				if(ufCtr->isPlacingOnSurface()){
 					Player *player = Game::getSingleton()->getPlayer(0);
 					GameObjectFrame &frame = ufCtr->getGameObjectFrame(0);
 					Model *model = frame.getModel();
@@ -678,7 +678,7 @@ namespace battleship{
                 break;
 			case Bind::ROTATE_OBJ_FRAME:
 				ufCtr->removeGameObjectFrames();
-				ufCtr->setPlacingFrames(false);
+				ufCtr->setPlacingOnSurface(false);
 				break;
 			case Bind::INCREASE_RADIUS:
 				if(isPressed) mapEditor->updateCircleRadius(true);

--- a/mapEditorAppState.cpp
+++ b/mapEditorAppState.cpp
@@ -676,7 +676,7 @@ namespace battleship{
 					CameraController::getSingleton()->setLookingAround(isPressed);
 
                 break;
-			case Bind::DESELECT_STRUCTURE:
+			case Bind::ROTATE_OBJ_FRAME:
 				ufCtr->removeGameObjectFrames();
 				ufCtr->setPlacingFrames(false);
 				break;

--- a/vehicle.cpp
+++ b/vehicle.cpp
@@ -261,6 +261,8 @@ namespace battleship{
 
 		int dest = map->getCellId(destPos);
 
+		if(type != UnitType::UNDERWATER && fabs(destPos.y - cells[dest].pos.y) > .1) return;
+
 		vector<float> heuristics;
 
 		for(Map::Cell &cell : cells)


### PR DESCRIPTION
Implemented adjustable submarine diving. To test:
1) select a submarine
2) hold the right mouse button anywhere over water
3) hold the space bar
4) move the mouse vertically to shift the depth
5) release the right mouse button to issue the order