### PR TITLE
bf-273-274-crash-fixes

### DIFF
--- a/activeGameState.cpp
+++ b/activeGameState.cpp
@@ -183,7 +183,7 @@ namespace battleship{
 			int unloadFlag = (int)shiftPressed;
 
 			if(!forceCursorState){
-				if(gameObjUnit && gameObjTransport){
+				if(gameObjUnit && ownGameObj && gameObjTransport){
 					orderPossible = (ownGameObj && canGarrison);
 					cursorState = CursorState::GARRISON;
 				}
@@ -289,6 +289,8 @@ namespace battleship{
 		guiManager->getText("wealth")->setText(to_wstring(mainPlayer->getResource(ResourceType::WEALTH)));
 		guiManager->getText("research")->setText(to_wstring(mainPlayer->getResource(ResourceType::RESEARCH)));
 
+		updateGameObjHoveredOn();
+
 		updateCursor();
 		Vector2 cursorPos = getCursorPos();
 
@@ -301,15 +303,13 @@ namespace battleship{
 
 		dragboxNode->setVisible(isSelectionBox);
 
-		updateGameObjHoveredOn();
-
 		vector<Unit*> selectedUnits = mainPlayer->getSelectedUnits();
 		GameObjectFrameController *fc = GameObjectFrameController::getSingleton();
 
 		if(!selectingDestOrient && orderMouseClicked && !selectedUnits.empty() && getTime() - lastOrderMouseClicked > 100){
 			if(targets.empty()) castRayToTerrain();
 
-			if(!buildableStructSelected)
+			if(!(buildableStructSelected || targets.empty()))
 				for(int i = 0; i < selectedUnits.size(); i++)
 					fc->addGameObjectFrame(GameObjectFrame(selectedUnits[i]->getId(), GameObject::Type::UNIT, mainPlayer, selectedUnits[i], targets[0].pos));
 
@@ -361,6 +361,9 @@ namespace battleship{
 			for(Unit *u : units)
 				gameObjs.push_back((GameObject*)u);
 		}
+
+		if(gameObjHoveredOn && find(gameObjs.begin(), gameObjs.end(), gameObjHoveredOn) == gameObjs.end())
+			gameObjHoveredOn = nullptr;
 
 		for(GameObject *gameObj : gameObjs)
 			if(isGameObjSelectable(gameObj, false)){
@@ -524,9 +527,10 @@ namespace battleship{
     void ActiveGameState::issueOrder(Order::TYPE type, vector<Order::Target> targets, bool addOrder) {
 		depth = 1;
 		Vector3 destDir =  Vector3::VEC_ZERO;
+		GameObjectFrameController *frameCtrl = GameObjectFrameController::getSingleton();
 		
-		if(selectingDestOrient){
-			GameObjectFrame &objFrame = GameObjectFrameController::getSingleton()->getGameObjectFrame(0);
+		if(selectingDestOrient && frameCtrl->getNumGameObjectFrames() > 0){
+			GameObjectFrame &objFrame = frameCtrl->getGameObjectFrame(0);
 			destDir = objFrame.getDirVec();
 			targets[0].pos = objFrame.getPos();
 		}

--- a/player.cpp
+++ b/player.cpp
@@ -111,12 +111,18 @@ namespace battleship{
 	}
 
 	void Player::issueOrder(Order::TYPE type, Vector3 destDir, vector<Order::Target> targets, bool append){
+		if(type != Order::TYPE::EJECT && targets.empty()) return;
+
 		vector<Unit*> selectedUnits = getSelectedUnits();
+		Vector3 mapSize = Map::getSingleton()->getMapSize();
 
         for (Unit *u : selectedUnits) {
 			bool targetingSelf = false, structBuilt = true;
 
 			for(Order::Target &targ : targets){
+				targ.pos.x = clamp(targ.pos.x, -.5f * mapSize.x, .5f * mapSize.x);
+				targ.pos.z = clamp(targ.pos.z, -.5f * mapSize.z, .5f * mapSize.z);
+
 				if(targ.unit && targ.unit == u){
 					targetingSelf = true;
 					break;


### PR DESCRIPTION
Bugfixes for crashes. To verify, try giving orders outside of the map or holding the cursor over soon to-be destroyed units.